### PR TITLE
fix: improve kitty tab contrast

### DIFF
--- a/extras/kanagawa.conf
+++ b/extras/kanagawa.conf
@@ -15,9 +15,9 @@ cursor #C8C093
 
 # Tabs
 active_tab_background #2D4F67
-active_tab_foreground #54546D
+active_tab_foreground #DCD7BA
 inactive_tab_background #223249
-inactive_tab_foreground #363646
+inactive_tab_foreground #727169
 #tab_bar_background #15161E
 
 # normal


### PR DESCRIPTION
Right now the foreground colors used in kitty tabs make the text very hard to read. I used lighter colors from the palette to improve contrast/legibility