### PR TITLE
fix user config override behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+/dependencies
 images/
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+NVIM_HEADLESS:=nvim --headless --noplugin -u tests/minimal_init.vim
+
+dependencies:
+	git clone --depth 1 https://github.com/nvim-lua/plenary.nvim dependencies/pack/vendor/start/plenary.nvim
+
+.PHONY: clean_dependencies
+clean_dependencies:
+	rm -rf dependencies
+
+.PHONY: clean
+clean: clean_dependencies
+
+.PHONY: test
+test: dependencies
+	INSTALL_ROOT_DIR=${INSTALL_ROOT_DIR} $(NVIM_HEADLESS) -c "call RunTests()"
+
+# vim:noexpandtab

--- a/lua/kanagawa/init.lua
+++ b/lua/kanagawa/init.lua
@@ -45,13 +45,25 @@ M.config = {
     -- bg_contrast = 'light'
 }
 
+---Extends the dest table with the src table, but _only_ one level deep (i.e., root values only).
+local function extend(dest, src)
+    for k, v in pairs(src) do
+        if dest[k] then
+            dest[k] = vim.tbl_extend("force", dest[k], v)
+        else
+            dest[k] = v
+        end
+    end
+    return dest
+end
+
 function M.setup(config)
     M.config = vim.tbl_extend("force", M.config, config or {}) -- override default config
-    local colors = vim.tbl_extend("force", require("kanagawa.colors"), M.config.colors) -- override palette colors
+    local colors = extend(require("kanagawa.colors"), M.config.colors) -- override palette colors
     colors:make_theme() -- generate semantic colors
-    colors = vim.tbl_extend("force", colors, M.config.colors) -- override semantic colors
+    colors = extend(colors, M.config.colors) -- override semantic colors
     M.colors = colors -- generate final color table
-    M.hlgroups = vim.tbl_extend("force", require("kanagawa.hlgroups"), M.config.overrides)
+    M.hlgroups = extend(require("kanagawa.hlgroups"), M.config.overrides)
 end
 
 return M

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,15 @@
+local kanagawa = require("kanagawa")
+local spy = require("luassert.spy")
+
+describe("config", function()
+    it("merges overrides with default highlight properties", function()
+        local vim_cmd = spy.on(vim, "cmd")
+        kanagawa.setup({
+            overrides = {
+                Comment = { fg = "#00aa00" },
+            },
+        })
+        kanagawa.load()
+        assert.spy(vim_cmd).was_called_with("highlight Comment guifg=#00aa00 gui=italic ")
+    end)
+end)

--- a/tests/fixtures/core_highlights.snapshot
+++ b/tests/fixtures/core_highlights.snapshot
@@ -1,0 +1,190 @@
+highlight Bold gui=bold
+highlight Boolean guifg=#FFA066 gui=bold
+highlight CmpDocumentation guifg=#DCD7BA
+highlight CmpDocumentationBorder guifg=#54546D guibg=#1F1F28
+highlight CmpItemAbbr guifg=#DCD7BA guibg=NONE
+highlight CmpItemAbbrDeprecated guibg=NONE gui=strikethrough
+highlight CmpItemAbbrMatch guifg=#7E9CD8 guibg=NONE
+highlight CmpItemKindDefault guifg=#717C7C guibg=NONE
+highlight CmpItemKindSnippet guifg=#7FB4CA guibg=NONE
+highlight CmpItemMenu guifg=#727169 guibg=NONE
+highlight ColorColumn guibg=#2A2A37
+highlight Comment guifg=#727169 gui=italic
+highlight Conceal guifg=#938AA9 guibg=NONE gui=bold
+highlight Constant guifg=#FFA066
+highlight Cursor guifg=#1F1F28 guibg=#DCD7BA
+highlight CursorLine guibg=#363646
+highlight CursorLineNr guifg=#FF9E3B guibg=#1F1F28 gui=bold
+highlight DashboardCenter guifg=#E6C384
+highlight DashboardFooter guifg=#7E9CD8
+highlight DashboardHeader guifg=#C34043
+highlight DashboardShortCut guifg=#7FB4CA
+highlight DiagnosticError guifg=#E82424
+highlight DiagnosticHint guifg=#6A9589
+highlight DiagnosticInfo guifg=#658594
+highlight DiagnosticUnderlineError gui=undercurl guisp=#E82424
+highlight DiagnosticUnderlineHint gui=undercurl guisp=#6A9589
+highlight DiagnosticUnderlineInfo gui=undercurl guisp=#658594
+highlight DiagnosticUnderlineWarn gui=undercurl guisp=#FF9E3B
+highlight DiagnosticWarn guifg=#FF9E3B
+highlight DiffAdd guifg=NONE guibg=#2B3328
+highlight DiffChange guifg=NONE guibg=#252535
+highlight DiffDelete guifg=#C34043 guibg=#43242B gui=none
+highlight DiffText guifg=NONE guibg=#49443C
+highlight Directory guifg=#7E9CD8
+highlight EndOfBuffer guifg=#1F1F28
+highlight Error guifg=#E82424 guibg=#1F1F28
+highlight ErrorMsg guifg=#E82424 guibg=#1F1F28
+highlight Exception guifg=#E46876
+highlight FloatBorder guifg=#54546D guibg=NONE
+highlight FoldColumn guifg=#54546D guibg=#1F1F28
+highlight Folded guifg=#938AA9 guibg=#2A2A37
+highlight Function guifg=#7E9CD8 gui=NONE
+highlight GitSignsDeleteLn guifg=NONE guibg=#43242B
+highlight Identifier guifg=#E6C384
+highlight IncSearch guifg=#223249 guibg=#FF9E3B gui=NONE
+highlight IndentBlanklineChar guifg=#54546D
+highlight IndentBlanklineContextChar guifg=#938AA9
+highlight IndentBlanklineContextStart gui=underline guisp=#938AA9
+highlight IndentBlanklineSpaceChar guifg=#54546D
+highlight IndentBlanklineSpaceCharBlankline guifg=#54546D
+highlight Italic gui=italic
+highlight Keyword guifg=#957FB8 gui=italic
+highlight LineNr guifg=#54546D
+highlight LspCodeLens guifg=#727169
+highlight LspReferenceText guibg=#49443C
+highlight LspSignatureActiveParameter guifg=#FF9E3B
+highlight MatchParen guifg=#FF9E3B guibg=NONE gui=bold
+highlight ModeMsg guifg=#FF9E3B guibg=#1F1F28 gui=bold
+highlight MoreMsg guifg=#658594 guibg=#1F1F28 gui=NONE
+highlight MsgArea guifg=#DCD7BA guibg=#1F1F28
+highlight NonText guifg=#54546D
+highlight Normal guifg=#DCD7BA guibg=#1F1F28
+highlight NormalFloat guifg=#DCD7BA guibg=#16161D
+highlight Number guifg=#D27E99
+highlight NvimTreeExecFile guifg=#98BB6C gui=bold
+highlight NvimTreeGitDeleted guifg=#C34043
+highlight NvimTreeGitDirty guifg=#DCA561
+highlight NvimTreeGitNew guifg=#76946A
+highlight NvimTreeGitStaged guifg=#76946A
+highlight NvimTreeImageFile guifg=#E46876
+highlight NvimTreeNormal guifg=#DCD7BA guibg=#1F1F28
+highlight NvimTreeOpenedFile guifg=#7FB4CA gui=italic
+highlight NvimTreeRootFolder guifg=#E6C384 gui=bold
+highlight NvimTreeSpecialFile guifg=#7FB4CA
+highlight Operator guifg=#C0A36E
+highlight Pmenu guifg=#DCD7BA guibg=#223249
+highlight PmenuSel guifg=NONE guibg=#2D4F67
+highlight PmenuThumb guibg=#2D4F67
+highlight PreProc guifg=#FFA066
+highlight Search guifg=#DCD7BA guibg=#2D4F67
+highlight SignColumn guibg=#1F1F28
+highlight Special guifg=#7FB4CA
+highlight SpellBad gui=undercurl guisp=#E82424
+highlight SpellCap gui=undercurl guisp=#FF9E3B
+highlight SpellLocal gui=undercurl guisp=#FF9E3B
+highlight SpellRare gui=undercurl guisp=#FF9E3B
+highlight Statement guifg=#957FB8 gui=bold
+highlight StatusLine guifg=#C8C093 guibg=#16161D gui=NONE
+highlight StatusLineNC guibg=#16161D gui=NONE
+highlight String guifg=#98BB6C
+highlight Substitute guifg=#DCD7BA guibg=#C34043
+highlight TSConstructor guifg=#957FB8
+highlight TSError guifg=#E82424
+highlight TSException guifg=#FF5D62 gui=bold
+highlight TSKeywordOperator guifg=#C0A36E gui=bold
+highlight TSKeywordReturn guifg=#FF5D62 gui=italic
+highlight TSPunctBracket guifg=#9CABCA
+highlight TSPunctDelimiter guifg=#9CABCA
+highlight TSPunctSpecial guifg=#9CABCA
+highlight TSStringEscape guifg=#C0A36E gui=bold
+highlight TSStringRegex guifg=#C0A36E
+highlight TSVariable guifg=#DCD7BA
+highlight TSVariableBuiltin guifg=#E46876 gui=italic
+highlight TabLine guifg=#938AA9 guibg=#16161D gui=NONE
+highlight TabLineFill guibg=#1F1F28 gui=NONE
+highlight TabLineSel guifg=#C8C093 guibg=#363646 gui=NONE
+highlight Title guifg=#7E9CD8 gui=bold
+highlight Todo guifg=#223249 guibg=#658594 gui=bold
+highlight Type guifg=#7AA89F gui=NONE
+highlight Underlined guifg=#7FB4CA gui=underline
+highlight VertSplit guifg=#16161D guibg=#16161D gui=NONE
+highlight Visual guibg=#223249
+highlight WarningMsg guifg=#C8C093
+highlight Whitespace guifg=#54546D
+highlight debugBreakpoint guifg=#7FB4CA
+highlight diffAdded guifg=#76946A
+highlight diffChanged guifg=#DCA561
+highlight diffDeleted guifg=#C34043
+highlight diffNewFile guifg=#76946A
+highlight diffOldFile guifg=#C34043
+highlight diffRemoved guifg=#C34043
+highlight healthError guifg=#E82424
+highlight healthSuccess guifg=#98BB6C
+highlight healthWarning guifg=#FF9E3B
+highlight! link Character String
+highlight! link CmpItemAbbrMatchFuzzy CmpItemAbbrMatch
+highlight! link CmpItemKindClass Type
+highlight! link CmpItemKindConstant Constant
+highlight! link CmpItemKindConstructor TSConstructor
+highlight! link CmpItemKindEnum Identifier
+highlight! link CmpItemKindEnumMember TSField
+highlight! link CmpItemKindField TSField
+highlight! link CmpItemKindFile Directory
+highlight! link CmpItemKindFolder Directory
+highlight! link CmpItemKindFunction Function
+highlight! link CmpItemKindInterface Type
+highlight! link CmpItemKindKeyword TSKeyword
+highlight! link CmpItemKindMethod Function
+highlight! link CmpItemKindModule TSInclude
+highlight! link CmpItemKindOperator Operator
+highlight! link CmpItemKindProperty TSProperty
+highlight! link CmpItemKindReference TSParameterReference
+highlight! link CmpItemKindStruct Type
+highlight! link CmpItemKindText TSText
+highlight! link CmpItemKindTypeParameter Identifier
+highlight! link CmpItemKindValue String
+highlight! link CmpItemKindVariable TSVariable
+highlight! link CursorColumn CursorLine
+highlight! link CursorIM Cursor
+highlight! link DiagnosticSignError DiagnosticError
+highlight! link DiagnosticSignHint DiagnosticHint
+highlight! link DiagnosticSignInfo DiagnosticInfo
+highlight! link DiagnosticSignWarn DiagnosticWarn
+highlight! link DiagnosticVirtualTextError DiagnosticError
+highlight! link DiagnosticVirtualTextHint DiagnosticHint
+highlight! link DiagnosticVirtualTextInfo DiagnosticInfo
+highlight! link DiagnosticVirtualTextWarn DiagnosticWarn
+highlight! link Float Number
+highlight! link GitSignsAdd diffAdded
+highlight! link GitSignsChange diffChanged
+highlight! link GitSignsDelete diffDeleted
+highlight! link Ignore NonText
+highlight! link LspReferenceRead LspReferenceText
+highlight! link LspReferenceWrite LspReferenceText
+highlight! link NormalNC Normal
+highlight! link NormalSB Normal
+highlight! link NvimTreeFolderName Directory
+highlight! link NvimTreeSymlink Type
+highlight! link PmenuSbar Pmenu
+highlight! link Question MoreMsg
+highlight! link QuickFixLine CursorLine
+highlight! link SignColumnSB SignColumn
+highlight! link SpecialKey NonText
+highlight! link TSAttribute Constant
+highlight! link TSDanger WarningMsg
+highlight! link TSField Identifier
+highlight! link TSKeyword Keyword
+highlight! link TSLabel Label
+highlight! link TSMethod Function
+highlight! link TSOperator Operator
+highlight! link TSParameter Identifier
+highlight! link TSProperty Identifier
+highlight! link TSWarning Todo
+highlight! link TelescopeBorder FloatBorder
+highlight! link VisualNOS Visual
+highlight! link WildMenu Pmenu
+highlight! link debugPC CursorLine
+highlight! link lCursor Cursor
+highlight! link qfFileName Directory
+highlight! link qfLineNr lineNr

--- a/tests/luassertx/lua/luassertx.lua
+++ b/tests/luassertx/lua/luassertx.lua
@@ -1,0 +1,73 @@
+local assert = require("luassert")
+local Path = require("plenary.path")
+
+local SnapshotMismatch = {}
+SnapshotMismatch.__index = SnapshotMismatch
+
+---@param snapshot_fixture string The fixture file.
+function SnapshotMismatch:new(snapshot_fixture)
+    return setmetatable({
+        snapshot_fixture = snapshot_fixture,
+        misses = {},
+    }, SnapshotMismatch)
+end
+
+function SnapshotMismatch:size()
+    return #self.misses
+end
+
+---@param line_no number The line number of the mismatch in the fixture file.
+---@param expected_val string
+---@param provided_val string
+function SnapshotMismatch:add(line_no, expected_val, provided_val)
+    self.misses[#self.misses + 1] = {
+        line_no = line_no,
+        expected_val = expected_val,
+        provided_val = provided_val,
+    }
+end
+
+function SnapshotMismatch:__tostring()
+    if #self.misses == 0 then
+        return "Snapshot matches"
+    end
+    return table.concat(
+        vim.tbl_map(function(miss)
+            return string.format(
+                "Snapshot mismatch on line %d:\n\tExpected<%q>\n\tReceived<%q>",
+                miss.line_no,
+                miss.expected_val,
+                miss.provided_val or ""
+            )
+        end, self.misses),
+        "\n"
+    )
+end
+
+---Provides a nicer snapshot file matcher implementation with better
+---error messaging than - the builtin "assert.equal" and the likes.
+local function matches_snapshot_line_by_line(state, arguments)
+    local provided_value = arguments[1]
+    local snapshot_fixture = arguments[2]
+    local snapshot = Path:new({ vim.loop.cwd(), "tests", "fixtures", snapshot_fixture }):read()
+    local trimmed_snapshot = snapshot:gsub("\n$", "") -- remove trailing newline in fixture file
+    local misses = SnapshotMismatch:new(snapshot_fixture)
+    for line_no, line in ipairs(vim.split(trimmed_snapshot, "\n")) do
+        if provided_value[line_no] == nil then
+            misses:add(line_no, line, provided_value[line_no])
+            state.failure_message = misses
+            return false
+        end
+        if provided_value[line_no] ~= line then
+            misses:add(line_no, line, provided_value[line_no])
+        end
+    end
+    if misses:size() > 0 then
+        state.failure_message = misses
+        return false
+    else
+        return true
+    end
+end
+
+assert:register("assertion", "matches_snapshot_line_by_line", matches_snapshot_line_by_line)

--- a/tests/minimal_init.vim
+++ b/tests/minimal_init.vim
@@ -13,13 +13,6 @@ set packpath=$dependencies
 lua require("luassertx")
 packloadall
 
-lua <<EOF
-local Path = require("plenary.path")
-function LoadFixture(file)
-    local path = Path:new { vim.loop.cwd(), "tests", "fixtures", file }
-end
-EOF
-
 function! RunTests() abort
     lua <<EOF
     require("plenary.test_harness").test_directory(os.getenv("FILE") or "./tests", {

--- a/tests/minimal_init.vim
+++ b/tests/minimal_init.vim
@@ -1,0 +1,29 @@
+" Avoid neovim/neovim#11362
+set display=lastline
+set directory=""
+set noswapfile
+
+let $kanagawa = getcwd()
+let $luassertx = getcwd() .. "/tests/luassertx"
+let $dependencies = getcwd() .. "/dependencies"
+
+set rtp+=$kanagawa,$luassertx
+set packpath=$dependencies
+
+lua require("luassertx")
+packloadall
+
+lua <<EOF
+local Path = require("plenary.path")
+function LoadFixture(file)
+    local path = Path:new { vim.loop.cwd(), "tests", "fixtures", file }
+end
+EOF
+
+function! RunTests() abort
+    lua <<EOF
+    require("plenary.test_harness").test_directory(os.getenv("FILE") or "./tests", {
+        minimal_init = vim.fn.getcwd() .. "/tests/minimal_init.vim",
+    })
+EOF
+endfunction

--- a/tests/snapshot_spec.lua
+++ b/tests/snapshot_spec.lua
@@ -1,0 +1,17 @@
+local kanagawa = require("kanagawa")
+local spy = require("luassert.spy")
+
+local function map_first_arg(call)
+    return vim.trim(call.vals[1]) -- we trim because the argument contains trailing whitespaces that we don't care about
+end
+
+describe("snapshots", function()
+    it("sets the expected highlight groups", function()
+        local vim_cmd = spy.on(vim, "cmd")
+        kanagawa.load()
+        -- Map the first arguments to vim.cmd to a list
+        local lines = vim.tbl_map(map_first_arg, vim_cmd.calls)
+        table.sort(lines)
+        assert.matches_snapshot_line_by_line(lines, "core_highlights.snapshot")
+    end)
+end)


### PR DESCRIPTION
Hello! Thanks for this colorscheme :). It seems like with https://github.com/rebelot/kanagawa.nvim/commit/d1d785c0a71f28f8f535c090f6bb22618f69dd4f, user configs no longer extend core properties (see comment here for further explanation https://github.com/rebelot/kanagawa.nvim/commit/d1d785c0a71f28f8f535c090f6bb22618f69dd4f#r62542103). I figured this was not intentional as it wasn't mentioned, so hence this PR.

The tests are probably overkill, I mostly did it for my own purposes to allow me to easier keep track of changes to the colorscheme.