### PR TITLE
Add pywal theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ vim.cmd("colorscheme kanagawa")
 * [kitty](extras/kanagawa.conf)
 * [iTerm](extras/kanagawa.itermcolors)
 * [alacritty](extras/alacritty_kanagawa.yml)
+* [pywal](extras/pywal-theme.json)
 * 🎉 Bonus! You win a tiny [python script](palette.py)🐍 to extract color palettes 🎨 from images! 🥳
 
 ## Acknowledgements

--- a/extras/pywal-theme.json
+++ b/extras/pywal-theme.json
@@ -1,0 +1,27 @@
+{
+    "colors": {
+        "color0": "#090618",
+        "color1": "#C34043",
+        "color2": "#76946A",
+        "color3": "#C0A36E",
+        "color4": "#7E9CD8",
+        "color5": "#957FB8",
+        "color6": "#6A9589",
+        "color7": "#C8C093",
+        "color8": "#727169",
+        "color9": "#E82424",
+        "color10": "#98BB6C",
+        "color11": "#E6C384",
+        "color12": "#7FB4CA",
+        "color13": "#938AA9",
+        "color14": "#7AA89F",
+        "color15": "#DCD7BA",
+        "color16": "#FFA066",
+        "color17": "#FF5D62"
+    },
+    "special": {
+        "foreground": "#DCD7BA",
+        "background": "#1F1F28",
+        "cursor": "#C8C093"
+    }
+}


### PR DESCRIPTION
[pywal](https://github.com/dylanaraps/pywal) project allows generating themes for many programs.
Having this single file will allow generating themes for all
programs supported by pywal using below command:

    wal -e -t -s --theme extras/pywal-theme.json # generated configs are in ~/.cache/wal/

List of supported programs can be found [here](https://github.com/dylanaraps/pywal/wiki/Customization)