### PR TITLE
Add wezterm theme

### DIFF
--- a/extras/wezterm.lua
+++ b/extras/wezterm.lua
@@ -1,0 +1,20 @@
+return {
+	colors = {
+		foreground = "#dcd7ba",
+		background = "#1f1f28",
+
+		cursor_bg = "#1f1f28",
+		cursor_fg = "#c8c093",
+		cursor_border = "#1f1f28",
+
+		selection_fg = "#c8c093",
+		selection_bg = "#2d4f67",
+
+		scrollbar_thumb = "#16161d",
+		split = "#16161d",
+
+		ansi = { "#090618", "#c34043", "#76946a", "#c0a36e", "#7e9cd8", "#957fb8", "#6a9589", "#c8c093" },
+		brights = { "#727169", "#e82424", "#98bb6c", "#e6c384", "#7fb4ca", "#938aa9", "#7aa89f", "#dcd7ba" },
+		indexed = { [16] = "#ffa066", [17] = "#ff5d62" },
+	},
+}


### PR DESCRIPTION
Theme for wezterm terminal emulator.
![kanagawa_wezterm](https://user-images.githubusercontent.com/93927273/148090611-69138272-ceb0-4637-a111-2076d953d46e.png)

