### PR TITLE
Add foot colorscheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ vim.cmd("colorscheme kanagawa")
 * [iTerm](extras/kanagawa.itermcolors)
 * [alacritty](extras/alacritty_kanagawa.yml)
 * [pywal](extras/pywal-theme.json)
+* [foot](extras/foot_kanagawa.ini)
 * 🎉 Bonus! You win a tiny [python script](palette.py)🐍 to extract color palettes 🎨 from images! 🥳
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ vim.cmd("colorscheme kanagawa")
 
 ## Extras
 
-* [kitty](extras/kanagawa.conf)
-* [iTerm](extras/kanagawa.itermcolors)
 * [alacritty](extras/alacritty_kanagawa.yml)
-* [pywal](extras/pywal-theme.json)
 * [foot](extras/foot_kanagawa.ini)
+* [iTerm](extras/kanagawa.itermcolors)
+* [kitty](extras/kanagawa.conf)
+* [pywal](extras/pywal-theme.json)
 * 🎉 Bonus! You win a tiny [python script](palette.py)🐍 to extract color palettes 🎨 from images! 🥳
 
 ## Acknowledgements

--- a/extras/foot_kanagawa.ini
+++ b/extras/foot_kanagawa.ini
@@ -1,0 +1,27 @@
+[colors]
+foreground = dcd7ba
+background = 1f1f28
+
+selection-foreground = c8c093
+selection-background = 2d4f67
+
+regular0 = 090618
+regular1 = c34043
+regular2 = 76946a
+regular3 = c0a36e
+regular4 = 7e9cd8
+regular5 = 957fb8
+regular6 = 6a9589
+regular7 = c8c093
+
+bright0  = 414868
+bright1  = f7768e
+bright2  = 9ece6a
+bright3  = e0af68
+bright4  = 7aa2f7
+bright5  = bb9af7
+bright6  = 7dcfff
+bright7  = c0caf5
+
+16       = ffa066
+17       = ff5d62


### PR DESCRIPTION
This is basically a straight port of the Alacritty theme for use with [foot](https://codeberg.org/dnkl/foot).

I also sorted the extras list since that'll make it easier to find things as more extras are added.