### PR TITLE
Add Fish shell theme

### DIFF
--- a/extras/kanagawa.fish
+++ b/extras/kanagawa.fish
@@ -1,0 +1,37 @@
+#!/usr/bin/fish
+
+# Kanagawa Fish shell theme
+# A template was taken and modified from Tokyonight:
+# https://github.com/folke/tokyonight.nvim/blob/main/extras/fish_tokyonight_night.fish
+set -l foreground DCD7BA
+set -l selection 2D4F67
+set -l comment 727169
+set -l red C34043
+set -l orange FF9E64
+set -l yellow C0A36E
+set -l green 76946A
+set -l purple 957FB8
+set -l cyan 7AA89F
+set -l pink D27E99
+
+# Syntax Highlighting Colors
+set -g fish_color_normal $foreground
+set -g fish_color_command $cyan
+set -g fish_color_keyword $pink
+set -g fish_color_quote $yellow
+set -g fish_color_redirection $foreground
+set -g fish_color_end $orange
+set -g fish_color_error $red
+set -g fish_color_param $purple
+set -g fish_color_comment $comment
+set -g fish_color_selection --background=$selection
+set -g fish_color_search_match --background=$selection
+set -g fish_color_operator $green
+set -g fish_color_escape $pink
+set -g fish_color_autosuggestion $comment
+
+# Completion Pager Colors
+set -g fish_pager_color_progress $comment
+set -g fish_pager_color_prefix $cyan
+set -g fish_pager_color_completion $foreground
+set -g fish_pager_color_description $comment


### PR DESCRIPTION
Add theme for [Fish](https://fishshell.com/). This fixes https://github.com/rebelot/kanagawa.nvim/issues/26

<img width="1312" alt="CleanShot 2022-01-18 at 17 55 07@2x" src="https://user-images.githubusercontent.com/831613/149961077-67bfffbc-9f73-4c90-99ff-1d87679eb7d4.png">
 