### PR TITLE
Theme config for Windows Terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ vim.cmd("colorscheme kanagawa")
 * [kitty](extras/kanagawa.conf)
 * [pywal](extras/pywal-theme.json)
 * [wezterm](extras/wezterm.lua)
+* [Windows Terminal](extras/windows_terminal.json)
 * 🎉 Bonus! You win a tiny [python script](palette.py)🐍 to extract color palettes 🎨 from any image! 🥳
 
 ## Acknowledgements

--- a/extras/windows_terminal.json
+++ b/extras/windows_terminal.json
@@ -10,14 +10,14 @@
     "brightRed": "#E82424",
     "brightWhite": "#DCD7BA",
     "brightYellow": "#E6C384",
-    "cursorColor": "#FFFFFF",
+    "cursorColor": "#C8C093",
     "cyan": "#6A9589",
     "foreground": "#DCD7BA",
     "green": "#76946A",
     "name": "Kanagawa",
     "purple": "#957FB8",
     "red": "#C34043",
-    "selectionBackground": "#FFFFFF",
+    "selectionBackground": "#2D4F67",
     "white": "#C8C093",
     "yellow": "#C0A36E"
 }

--- a/extras/windows_terminal.json
+++ b/extras/windows_terminal.json
@@ -1,0 +1,23 @@
+{
+    "background": "#1F1F28",
+    "black": "#090618",
+    "blue": "#7E9CD8",
+    "brightBlack": "#727169",
+    "brightBlue": "#7FB4CA",
+    "brightCyan": "#7AA89F",
+    "brightGreen": "#98BB6C",
+    "brightPurple": "#938AA9",
+    "brightRed": "#E82424",
+    "brightWhite": "#DCD7BA",
+    "brightYellow": "#E6C384",
+    "cursorColor": "#FFFFFF",
+    "cyan": "#6A9589",
+    "foreground": "#DCD7BA",
+    "green": "#76946A",
+    "name": "Kanagawa",
+    "purple": "#957FB8",
+    "red": "#C34043",
+    "selectionBackground": "#FFFFFF",
+    "white": "#C8C093",
+    "yellow": "#C0A36E"
+}


### PR DESCRIPTION
Color scheme support for the Windows Terminal, which uses a `settings.json` to set color schemes and other terminal settings.
This has to be added to the existing list of color schemes ("schemes": [...]) to work.