### PR TITLE
Add explicit support for 'mini.nvim'

### DIFF
--- a/lua/kanagawa/highlights/plugins.lua
+++ b/lua/kanagawa/highlights/plugins.lua
@@ -257,6 +257,139 @@ function M.setup(colors, config)
         AerialEventIcon = { link = "Structure" },
         AerialOperatorIcon = { link = "Operator" },
         AerialTypeParameterIcon = { link = "Type" },
+
+        -- Mini
+        MiniAnimateCursor = { reverse = true, nocombine = true },
+        MiniAnimateNormalFloat = { link = "NormalFloat" },
+
+        MiniClueBorder = { link = "FloatBorder" },
+        MiniClueDescGroup = { link = "DiagnosticFloatingWarn" },
+        MiniClueDescSingle = { link = "NormalFloat" },
+        MiniClueNextKey = { link = "DiagnosticFloatingHint" },
+        MiniClueNextKeyWithPostkeys = { link = "DiagnosticFloatingError" },
+        MiniClueSeparator = { link = "DiagnosticFloatingInfo" },
+        MiniClueTitle = { link = "FloatTitle" },
+
+        MiniCompletionActiveParameter = { underline = true },
+
+        MiniCursorword = { underline = true },
+        MiniCursorwordCurrent = { underline = true },
+
+        MiniDepsChangeAdded = { link = "diffAdded" },
+        MiniDepsChangeRemoved = { link = "diffRemoved" },
+        MiniDepsHint = { fg = theme.diag.hint },
+        MiniDepsInfo = { fg = theme.diag.info },
+        MiniDepsMsgBreaking = { fg = theme.diag.warning },
+        MiniDepsPlaceholder = { link = "Comment" },
+        MiniDepsTitle = { link = "Title" },
+        MiniDepsTitleError = { link = "DiffDelete" },
+        MiniDepsTitleSame = { link = "DiffText" },
+        MiniDepsTitleUpdate = { link = "DiffAdd" },
+
+        MiniDiffSignAdd = { fg = theme.vcs.added, bg = theme.ui.bg_gutter },
+        MiniDiffSignChange = { fg = theme.vcs.changed, bg = theme.ui.bg_gutter },
+        MiniDiffSignDelete = { fg = theme.vcs.removed, bg = theme.ui.bg_gutter },
+        MiniDiffOverAdd = { link = "DiffAdd" },
+        MiniDiffOverChange = { link = "DiffText" },
+        MiniDiffOverContext = { link = "DiffChange" },
+        MiniDiffOverDelete = { link = "DiffDelete" },
+
+        MiniFilesBorder = { link = "FloatBorder" },
+        MiniFilesBorderModified = { link = "DiagnosticFloatingWarn" },
+        MiniFilesCursorLine = { link = "CursorLine" },
+        MiniFilesDirectory = { link = "Directory" },
+        MiniFilesFile = { fg = theme.ui.fg },
+        MiniFilesNormal = { link = "NormalFloat" },
+        MiniFilesTitle = { fg = theme.ui.special, bg = theme.ui.float.bg_border, bold = true },
+        MiniFilesTitleFocused = { fg = theme.ui.fg, bg = theme.ui.float.bg_border, bold = true },
+
+        MiniHipatternsFixme = { fg = theme.ui.bg, bg = theme.diag.error, bold = true },
+        MiniHipatternsHack = { fg = theme.ui.bg, bg = theme.diag.warning, bold = true },
+        MiniHipatternsNote = { fg = theme.ui.bg, bg = theme.diag.info, bold = true },
+        MiniHipatternsTodo = { fg = theme.ui.bg, bg = theme.diag.hint, bold = true },
+
+        MiniIconsAzure = { fg = theme.syn.special1 },
+        MiniIconsBlue = { fg = theme.syn.fun },
+        MiniIconsCyan = { fg = theme.syn.type },
+        MiniIconsGreen = { fg = theme.syn.string },
+        MiniIconsGrey = { fg = theme.ui.fg },
+        MiniIconsOrange = { fg = theme.syn.constant },
+        MiniIconsPurple = { fg = theme.syn.keyword },
+        MiniIconsRed = { fg = theme.syn.special3 },
+        MiniIconsYellow = { fg = theme.syn.identifier },
+
+        MiniIndentscopeSymbol = { fg = theme.syn.special1 },
+        MiniIndentscopePrefix = { nocombine = true }, -- Make it invisible
+
+        MiniJump = { link = "SpellRare" },
+
+        MiniJump2dDim = { link = "Comment" },
+        MiniJump2dSpot = { fg = theme.syn.constant, bold = true, nocombine = true },
+        MiniJump2dSpotAhead = { fg = theme.diag.hint, bg = theme.ui.bg_dim, nocombine = true },
+        MiniJump2dSpotUnique = { fg = theme.syn.special1, bold = true, nocombine = true },
+
+        MiniMapNormal = { link = "NormalFloat" },
+        MiniMapSymbolCount = { link = "Special" },
+        MiniMapSymbolLine = { link = "Title" },
+        MiniMapSymbolView = { link = "Delimiter" },
+
+        MiniNotifyBorder = { link = "FloatBorder" },
+        MiniNotifyNormal = { link = "NormalFloat" },
+        MiniNotifyTitle = { link = "FloatTitle" },
+
+        MiniOperatorsExchangeFrom = { link = "IncSearch" },
+
+        MiniPickBorder = { link = "FloatBorder" },
+        MiniPickBorderBusy = { link = "DiagnosticFloatingWarn" },
+        MiniPickBorderText = { link = "FloatTitle" },
+        MiniPickIconDirectory = { link = "Directory" },
+        MiniPickIconFile = { link = "MiniPickNormal" },
+        MiniPickHeader = { link = "DiagnosticFloatingHint" },
+        MiniPickMatchCurrent = { link = "CursorLine" },
+        MiniPickMatchMarked = { link = "Visual" },
+        MiniPickMatchRanges = { link = "DiagnosticFloatingHint" },
+        MiniPickNormal = { link = "NormalFloat" },
+        MiniPickPreviewLine = { link = "CursorLine" },
+        MiniPickPreviewRegion = { link = "IncSearch" },
+        MiniPickPrompt = { fg = theme.syn.fun, bg = theme.ui.float.bg_border },
+
+        MiniStarterCurrent = { nocombine = true },
+        MiniStarterFooter = { fg = theme.syn.deprecated },
+        MiniStarterHeader = { link = "Title" },
+        MiniStarterInactive = { link = "Comment" },
+        MiniStarterItem = { link = "Normal" },
+        MiniStarterItemBullet = { link = "Delimiter" },
+        MiniStarterItemPrefix = { fg = theme.diag.warning },
+        MiniStarterSection = {  fg = theme.diag.ok },
+        MiniStarterQuery = { fg = theme.diag.info },
+
+        MiniStatuslineDevinfo = { fg = theme.ui.fg_dim, bg = theme.ui.bg_p1 },
+        MiniStatuslineFileinfo = { fg = theme.ui.fg_dim, bg = theme.ui.bg_p1 },
+        MiniStatuslineFilename = { fg = theme.ui.fg_dim, bg = theme.ui.bg_dim },
+        MiniStatuslineInactive = { link = "StatusLineNC" },
+        MiniStatuslineModeCommand = { fg = theme.ui.bg, bg = theme.syn.operator, bold = true },
+        MiniStatuslineModeInsert = { fg = theme.ui.bg, bg = theme.diag.ok, bold = true },
+        MiniStatuslineModeNormal = { fg = theme.ui.bg_m3, bg = theme.syn.fun, bold = true },
+        MiniStatuslineModeOther = { fg = theme.ui.bg, bg = theme.syn.type, bold = true },
+        MiniStatuslineModeReplace = { fg = theme.ui.bg, bg = theme.syn.constant, bold = true },
+        MiniStatuslineModeVisual = { fg = theme.ui.bg, bg = theme.syn.keyword, bold = true },
+
+        MiniSurround = { link = "IncSearch" },
+
+        MiniTablineCurrent = { fg = theme.ui.fg_dim, bg = theme.ui.bg_p1, bold = true },
+        MiniTablineFill = { link = "TabLineFill" },
+        MiniTablineHidden = { fg = theme.ui.special, bg = theme.ui.bg_m3 },
+        MiniTablineModifiedCurrent = { fg = theme.ui.bg_p1, bg = theme.ui.fg_dim, bold = true },
+        MiniTablineModifiedHidden = { fg = theme.ui.bg_m3, bg = theme.ui.special },
+        MiniTablineModifiedVisible = { fg = theme.ui.bg_m3, bg = theme.ui.special, bold = true },
+        MiniTablineTabpagesection = { fg = theme.ui.fg, bg = theme.ui.bg_search, bold = true },
+        MiniTablineVisible = { fg = theme.ui.special, bg = theme.ui.bg_m3, bold = true },
+
+        MiniTestEmphasis = { bold = true },
+        MiniTestFail = { fg = theme.diag.error, bold = true },
+        MiniTestPass = { fg = theme.diag.ok, bold = true },
+
+        MiniTrailspace = { bg = theme.vcs.removed },
     }
 end
 


### PR DESCRIPTION
Hi! I would like to add explicit support for [mini.nvim](https://github.com/echasnovski/mini.nvim).

Basic choices are taken from either highlight groups to which 'mini.nvim' makes default links or from analogous plugins.

Differences from default linked groups:
- 'mini.indentscope' is based on 'indent-blankline'.
- 'mini.jump2d' takes color from "SpellRare" to be consistent with 'mini.jump'. Using `nocombine = true` to be consistent (not have italic labels on italic text).
- 'mini.starter' is based on 'dashboard.lua', 'whichkey.lua', 'telescope.lua', and personal choices:
    - `MiniStarterSection` is chosen to be visible (as from "Special" highlight group).
    - `MiniStarterItemBullet` is as border.
    - `MiniStarterItemPrefix` and `MiniStarterQuery` are based on "warning" and "info" diagnostic colors to be opposite of each other.
- 'mini.statusline' is based on 'lualine/themes/kanagawa.lua' and personal choices:
    - All `MiniStatuslineMode*` have bold text as this seems to be used in screenshot.
    - `MiniStatuslineDevinfo` and `MiniStatuslineFileinfo` are "slightly different text".
    - `MiniStatuslineModeOther` is chosen to be different from others.
- 'mini.tabline' is based on explicit 'TabLine*' groups:
    - `MiniTablineCurrent` has bold font to be visually distinctive.
    - `MiniTablineVisible` has slightly darker foreground than `MiniTablineCurrent`.
    - `MiniTablineTabpagesection` is chosen from `Search`.
    - `MiniTablineModified*` groups have inverted `fg` and `bg` of their counterparts.
- 'mini.test' has red for fail and green for pass. Red and green chosen to be visible inside floating window.
- 'mini.trailspace' has group with red background to draw attention.

**Edit**: I've made a second iteration which:
- Resolves conflicts.
- Uses colors attributes only from `theme`.
- Adds explicit support for highlight groups from new modules  that were released in the past two years and for the (hopefully) upcoming 'mini.icons'.

Before:

![kanagawa_before](https://github.com/rebelot/kanagawa.nvim/assets/24854248/6db8c9fc-d291-4846-8731-4f5070109fe6)

After:

![kanagawa_after](https://github.com/rebelot/kanagawa.nvim/assets/24854248/0e736f85-c67d-4522-94aa-6b241c794109)