### PR TITLE
fix: use EmmyLua-style code annotations

### DIFF
--- a/lua/kanagawa/colors.lua
+++ b/lua/kanagawa/colors.lua
@@ -1,3 +1,4 @@
+---@class KanagawaColors
 local palette_colors = {
 
     -- Bg Shades
@@ -60,8 +61,8 @@ local palette_colors = {
 local M = {}
 
 --- generate color table
--- @param config config options containing colors and theme fields (optional)
--- @return table of palette colors and theme colors merged with config.colors
+---@param config table<string, string>? Config options containing colors and theme fields (optional)
+---@return KanagawaColors # Palette colors and theme colors merged with config.colors
 function M.setup(config)
     config = vim.tbl_extend("force", require("kanagawa").config, config or {})
     local colors = vim.tbl_extend("force", palette_colors, config.colors)

--- a/lua/kanagawa/hlgroups.lua
+++ b/lua/kanagawa/hlgroups.lua
@@ -22,8 +22,8 @@ local function setup_terminal_colors(colors)
 end
 
 --- generate highlights table
--- @param colors color (theme) color table created by require("kanagawa.colors").setup()
--- @param config config options (optional)
+---@param colors table<string, string> color (theme) color table created by require("kanagawa.colors").setup()
+---@param config table? config options (optional)
 function M.setup(colors, config)
     config = vim.tbl_extend("force", require("kanagawa").config, config or {})
 

--- a/lua/kanagawa/init.lua
+++ b/lua/kanagawa/init.lua
@@ -40,6 +40,7 @@ local function check_config(config)
 end
 
 --- default config
+---@class KanagawaConfig
 M.config = {
     undercurl = true,
     commentStyle = { italic = true },
@@ -54,14 +55,15 @@ M.config = {
     dimInactive = false,
     globalStatus = false,
     terminalColors = true,
+    ---@type KanagawaColors
     colors = {},
+    ---@type KanagawaColors
     overrides = {},
     theme = "default", -- only one theme atm
 }
 
 --- update global configuration with user settings
---@param config user configuration
---@return nil
+---@param config KanagawaConfig? user configuration
 function M.setup(config)
     M.config = vim.tbl_extend("force", M.config, config or {})
     check_config(M.config)


### PR DESCRIPTION
This is also the annotation style that the lua-language-server
implements.

This gives a bit richer diagnostics and autocompletions, for example:

<img width="649" alt="Screenshot 2022-08-13 at 15 36 36" src="https://user-images.githubusercontent.com/6705160/184515850-c8364bc8-a39f-4580-a7dc-d74c786e524a.png">
<img width="561" alt="Screenshot 2022-08-13 at 15 38 48" src="https://user-images.githubusercontent.com/6705160/184515851-bf916c4e-940a-4a0c-b83d-0ab5d9b690cb.png">

