### PR TITLE
Fix missing tag highlights

### DIFF
--- a/lua/kanagawa/hlgroups.lua
+++ b/lua/kanagawa/hlgroups.lua
@@ -261,6 +261,9 @@ function M.setup(colors, config)
 
         -- TSTag = {},
         -- TSTagDelimiter = {},
+        ["@tag"] = { link = "Tag" },
+        ["@tag.delimiter"] = { fg = colors.br },
+        ["@tag.attribute"] = { link = "Constant" },
         -- TSText = {},
         -- TSTextReference = { fg = c.sp2 },
         -- TSEmphasis = {},


### PR DESCRIPTION
Fix #80 by defining the tag, tag.delimiter, and tag.attribute groups.

Before:
<img width="805" alt="Screen Shot 2022-10-26 at 2 25 50 PM" src="https://user-images.githubusercontent.com/48893929/198107284-8007a0d1-905b-47d5-9f74-1d1355617363.png">

After:
<img width="815" alt="Screen Shot 2022-10-26 at 2 26 41 PM" src="https://user-images.githubusercontent.com/48893929/198107155-a542ab66-0154-4a36-a90e-08b7d4098c0c.png">
