### PR TITLE
Allow for color ordering

### DIFF
--- a/palette.py
+++ b/palette.py
@@ -1,41 +1,54 @@
-from skimage import io, color
-from skimage.transform import rescale
-from sklearn.cluster import KMeans
+import argparse
+import colorsys
+
 import matplotlib.pyplot as plt
 import numpy as np
-import argparse
+from skimage import color, io
+from skimage.transform import rescale
+from sklearn.cluster import KMeans
 
-def palette(img, n=10, r=1):
-    img = img[:,:,(0,1,2)]
+
+def palette(img, n=10, r=1, o=False):
+    img = img[:, :, (0, 1, 2)]
     img = rescale(img, (r, r, 1), anti_aliasing=True)
-    lab = color.rgb2lab(img).reshape(-1,3)
+    lab = color.rgb2lab(img).reshape(-1, 3)
     km = KMeans(n_clusters=n, random_state=0).fit(lab)
-    cc = km.cluster_centers_.reshape(-1,1,3).transpose((1,0,2))
+    cc = km.cluster_centers_.reshape(-1, 1, 3).transpose((1, 0, 2))
+
+    if o:
+        rgb_x = color.lab2rgb(cc)
+        initial_colors = list(rgb_x[0])
+        initial_colors.sort(key=lambda c: colorsys.rgb_to_hsv(*c))
+
+        return np.asarray([initial_colors])
+
     return color.lab2rgb(cc)
 
 def p2h(p):
-     r, g, b = np.round(p).astype(int)
-     return f"#{r:02X}{g:02X}{b:02X}"
+    r, g, b = np.round(p).astype(int)
+    return f"#{r:02X}{g:02X}{b:02X}"
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('img')
-    parser.add_argument('out')
-    parser.add_argument('-n', default=10, type=int)
-    parser.add_argument('-r', default=1, type=float)
+    parser.add_argument("img")
+    parser.add_argument("out")
+    parser.add_argument("-n", default=10, type=int, help="The number of colors for the palette")
+    parser.add_argument("-r", default=1, type=float, help="Rescale factor")
+    parser.add_argument("-o", default=False, action='store_true')
     args = parser.parse_args()
     img = io.imread(args.img)
-    p = palette(img, n=args.n, r=args.r)
+    p = palette(img, n=args.n, r=args.r, o=args.o)
     h = [p2h(rgb * 255) for rgb in p[0]]
     ax = plt.axes()
     ax.imshow(img)
     ax.set_axis_off()
-    axin = ax.inset_axes([0.2,0.2, 0.6, 0.2])
+    axin = ax.inset_axes([0.2, 0.2, 0.6, 0.2])
     axin.set_axis_off()
-    axin.imshow(p, aspect='auto')
-    plt.savefig(args.out, dpi=800, pad_inches=0, bbox_inches='tight')
+    axin.imshow(p, aspect="auto")
+    plt.savefig(args.out, dpi=800, pad_inches=0, bbox_inches="tight")
     print("\n".join(h))
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This script to output the image's color palette is incredibly handy. However, my only nitpick is the order in which the colors are exported. I added an optional argument to allow the export of the palette ordered by Hue (Rainbow like).
[Ordering color is complicated](https://www.alanzucconi.com/2015/09/30/colour-sorting/).

The change is smaller than it actually appears in the diff. I ran `isort`, to sort the imports, and `black`, to format the script.