### PR TITLE
fix(hlgroups): symbol

### DIFF
--- a/lua/kanagawa/hlgroups.lua
+++ b/lua/kanagawa/hlgroups.lua
@@ -254,7 +254,7 @@ function M.setup(colors, config)
         -- TSString = {},
         ["@string.regex"] = { fg = colors.re },
         ["@string.escape"] = { fg = colors.re, bold = true },
-        -- TSSymbol = {},
+        ["@symbol"] = { fg = colors.id },
         -- TSType = {},
         -- TSTypeBuiltin = {},
         ["@variable"] = { fg = colors.fg },


### PR DESCRIPTION
fixes: https://github.com/rebelot/kanagawa.nvim/issues/91

after:
<img width="178" alt="image" src="https://user-images.githubusercontent.com/9551316/210149905-2d303c0d-a50c-4b53-8dfb-97776904614b.png">
