### PR TITLE
fix(hlgroups): tag attribute color

### DIFF
--- a/lua/kanagawa/hlgroups.lua
+++ b/lua/kanagawa/hlgroups.lua
@@ -264,7 +264,7 @@ function M.setup(colors, config)
         -- TSTagDelimiter = {},
         ["@tag"] = { link = "Tag" },
         ["@tag.delimiter"] = { fg = colors.br },
-        ["@tag.attribute"] = { link = "Constant" },
+        ["@tag.attribute"] = { fg = colors.id },
         -- TSText = {},
         -- TSTextReference = { fg = c.sp2 },
         -- TSEmphasis = {},


### PR DESCRIPTION
Before:

<img width="371" alt="Captura de Tela 2022-12-31 às 19 21 25" src="https://user-images.githubusercontent.com/9551316/210153828-49f165e0-3c05-4e15-9dc4-31d8d25851a3.png">

After:

<img width="362" alt="image" src="https://user-images.githubusercontent.com/9551316/210153847-51b6f46d-89bd-44c3-bd01-7484f407e70d.png">

(Helix as base):

<img width="365" alt="Captura de Tela 2022-12-31 às 19 21 30" src="https://user-images.githubusercontent.com/9551316/210153830-fd79edaf-0978-4c75-80ba-46606c492614.png">

