### PR TITLE
Add fallback colors to fish highlighting

### DIFF
--- a/extras/kanagawa.fish
+++ b/extras/kanagawa.fish
@@ -3,16 +3,16 @@
 # Kanagawa Fish shell theme
 # A template was taken and modified from Tokyonight:
 # https://github.com/folke/tokyonight.nvim/blob/main/extras/fish_tokyonight_night.fish
-set -l foreground DCD7BA
-set -l selection 2D4F67
-set -l comment 727169
-set -l red C34043
-set -l orange FF9E64
-set -l yellow C0A36E
-set -l green 76946A
-set -l purple 957FB8
-set -l cyan 7AA89F
-set -l pink D27E99
+set -l foreground DCD7BA normal
+set -l selection 2D4F67 brcyan
+set -l comment 727169 brblack
+set -l red C34043 red
+set -l orange FF9E64 brred
+set -l yellow C0A36E yellow
+set -l green 76946A green
+set -l purple 957FB8 magenta
+set -l cyan 7AA89F cyan
+set -l pink D27E99 brmagenta
 
 # Syntax Highlighting Colors
 set -g fish_color_normal $foreground


### PR DESCRIPTION
On 8/16 color terminals, like the Linux console, the color interpolation on the 24 bit colors in this colorscheme lead to undesirable results, like the prefix of a valid command looking the same as the completion suggestion.

The set_color command in fish supports a fallback color as a second positional argument, which is documented here:
https://fishshell.com/docs/current/cmds/set_color.html

This commit introduces fallback colors which are recognized by 16 color terminals. On the Linux console I tested this on, there is no difference between the bright and non-bright colors, except for black, whose bright variant is gray.

I did not test this on a 256-color terminal. There it might be preferable to have no fallback but use interpolation instead.