### PR TITLE
feat: add in support for Note

### DIFF
--- a/lua/kanagawa/highlights/treesitter.lua
+++ b/lua/kanagawa/highlights/treesitter.lua
@@ -126,6 +126,7 @@ function M.setup(colors, config)
 
         -- @text.todo (Todo)                           ; todo notes
         -- @text.note                                  ; info notes
+        ["@text.note"] = { fg = theme.ui.fg_reverse, bg = theme.diag.hint, bold = true },
         -- @text.warning                               ; warning notes
         ["@text.warning"] = { fg = theme.ui.fg_reverse, bg = theme.diag.warning, bold = true },
         -- @text.danger                                ; danger/error notes


### PR DESCRIPTION
This supersedes #99 since everything was refactored. This adds in
support for highlighting of `NOTE` since currently it's not supported.
