### PR TITLE
feat: add syntax style options

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,16 @@ require('kanagawa').setup({
     compile = false,             -- enable compiling the colorscheme
     undercurl = true,            -- enable undercurls
     styles = {
+        booleans = { bold = true },
+        builtinVariables = { italic = true },
         comments = { italic = true },
         functions = {},
-        keywords = { italic = true},
+        keywords = { italic = true },
+        operators = { bold = true },
+        semanticFunctions = { bold = true },
         statements = { bold = true },
-        typeStyle = {},
+        stringEscapes = { bold = true },
+        types = {},
     },
     transparent = false,         -- do not set background color
     dimInactive = false,         -- dim inactive window `:h hl-NormalNC`

--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ There is no need to call setup if you are ok with the defaults.
 require('kanagawa').setup({
     compile = false,             -- enable compiling the colorscheme
     undercurl = true,            -- enable undercurls
-    commentStyle = { italic = true },
-    functionStyle = {},
-    keywordStyle = { italic = true},
-    statementStyle = { bold = true },
-    typeStyle = {},
+    styles = {
+        comments = { italic = true },
+        functions = {},
+        keywords = { italic = true},
+        statements = { bold = true },
+        typeStyle = {},
+    },
     transparent = false,         -- do not set background color
     dimInactive = false,         -- dim inactive window `:h hl-NormalNC`
     terminalColors = true,       -- define vim.g.terminal_color_{0,17}

--- a/lua/kanagawa/highlights/lsp.lua
+++ b/lua/kanagawa/highlights/lsp.lua
@@ -50,7 +50,7 @@ function M.setup(colors, config)
             ["@lsp.typemod.string.injected"] = { link = "String" },
             ["@lsp.typemod.variable.injected"] = { link = "@variable" },
 
-            ["@lsp.typemod.function.readonly"] = { fg = theme.syn.fun, bold = true }
+            ["@lsp.typemod.function.readonly"] = vim.tbl_extend("force", { fg = theme.syn.fun }, config.styles.readonlyFunctions)
     }
 end
 

--- a/lua/kanagawa/highlights/syntax.lua
+++ b/lua/kanagawa/highlights/syntax.lua
@@ -20,7 +20,7 @@ function M.setup(colors, config)
         --  Number		a number constant: 234, 0xff
         Number = { fg = theme.syn.number },
         --  Boolean	a boolean constant: TRUE, false
-        Boolean = { fg = theme.syn.constant, bold = true },
+        Boolean = vim.tbl_extend("force", { fg = theme.syn.constant }, config.styles.booleans),
         --  Float		a floating point constant: 2.3e10
         Float = { link = "Number" },
 

--- a/lua/kanagawa/highlights/syntax.lua
+++ b/lua/kanagawa/highlights/syntax.lua
@@ -9,7 +9,7 @@ function M.setup(colors, config)
 
     return {
         -- *Comment	any comment
-        Comment = vim.tbl_extend("force", { fg = theme.syn.comment }, config.commentStyle),
+        Comment = vim.tbl_extend("force", { fg = theme.syn.comment }, config.styles.comments),
 
         -- *Constant	any constant
         Constant = { fg = theme.syn.constant },
@@ -27,17 +27,17 @@ function M.setup(colors, config)
         -- *Identifier	any variable name
         Identifier = { fg = theme.syn.identifier },
         --  Function	function name (also: methods for classes)
-        Function = vim.tbl_extend("force", { fg = theme.syn.fun }, config.functionStyle),
+        Function = vim.tbl_extend("force", { fg = theme.syn.fun }, config.styles.functions),
 
         -- *Statement	any statement
-        Statement = vim.tbl_extend("force", { fg = theme.syn.statement }, config.statementStyle),
+        Statement = vim.tbl_extend("force", { fg = theme.syn.statement }, config.styles.statements),
         --  Conditional	if, then, else, endif, switch, etc.
         --  Repeat		for, do, while, etc.
         --  Label		case, default, etc.
         --  Operator	"sizeof", "+", "*", etc.
         Operator = { fg = theme.syn.operator },
         --  Keyword	any other keyword
-        Keyword = vim.tbl_extend("force", { fg = theme.syn.keyword }, config.keywordStyle),
+        Keyword = vim.tbl_extend("force", { fg = theme.syn.keyword }, config.styles.keywords),
         --  Exception	try, catch, throw
         Exception = { fg = theme.syn.special2 },
 
@@ -49,7 +49,7 @@ function M.setup(colors, config)
         --  PreCondit	preprocessor #if, #else, #endif, etc.
 
         -- *Type		int, long, char, etc.
-        Type = vim.tbl_extend("force", { fg = theme.syn.type }, config.typeStyle),
+        Type = vim.tbl_extend("force", { fg = theme.syn.type }, config.styles.types),
         --  StorageClass	static, register, volatile, etc.
         --  Structure	struct, union, enum, etc.
         --  Typedef	A typedef

--- a/lua/kanagawa/highlights/treesitter.lua
+++ b/lua/kanagawa/highlights/treesitter.lua
@@ -10,7 +10,7 @@ function M.setup(colors, config)
         -- @variable (Identifier)                      ; various variable names
         ["@variable"] = { fg = theme.ui.fg },
         -- @variable.builtin                           ; built-in variable names (e.g. `this`)
-        ["@variable.builtin"] = { fg = theme.syn.special2, italic = true },
+        ["@variable.builtin"] = vim.tbl_extend("force", { fg = theme.syn.special2 }, config.styles.builtinVariables),
         -- @variable.parameter                         ; parameters of a function
         ["@variable.parameter"] = { fg = theme.syn.parameter },
         -- @variable.member                            ; object and struct fields
@@ -31,7 +31,7 @@ function M.setup(colors, config)
         -- @string.regexp                              ; regular expressions
         ["@string.regexp"] = { fg = theme.syn.regex },
         -- @string.escape (SpecialChar)                ; escape sequences
-        ["@string.escape"] = { fg = theme.syn.regex, bold = true },
+        ["@string.escape"] = vim.tbl_extend("force", { fg = theme.syn.regex }, config.styles.stringEscapes),
         -- @string.special (SpecialChar)               ; other special strings (e.g. dates)
         -- @string.special.symbol                      ; symbols or atoms
         ["@string.special.symbol"] = { fg = theme.syn.identifier },
@@ -77,7 +77,7 @@ function M.setup(colors, config)
         -- @keyword.coroutine                          ; keywords related to coroutines (e.g. `go` in Go, `async/await` in Python)
         -- @keyword.function                           ; keywords that define a function (e.g. `func` in Go, `def` in Python)
         -- @keyword.operator                           ; operators that are English words (e.g. `and` / `or`)
-        ["@keyword.operator"] = { fg = theme.syn.operator, bold = true },
+        ["@keyword.operator"] = vim.tbl_extend("force", { fg = theme.syn.operator }, config.styles.operators),
         -- @keyword.import                             ; keywords for including modules (e.g. `import` / `from` in Python)
         ["@keyword.import"] = { link = "PreProc" },
         -- @keyword.storage (StorageClass)             ; modifiers that affect storage in memory or life-time

--- a/lua/kanagawa/highlights/treesitter.lua
+++ b/lua/kanagawa/highlights/treesitter.lua
@@ -83,10 +83,10 @@ function M.setup(colors, config)
         -- @keyword.storage (StorageClass)             ; modifiers that affect storage in memory or life-time
         -- @keyword.repeat  (Repeat)                   ; keywords related to loops (e.g. `for` / `while`)
         -- @keyword.return                             ; keywords like `return` and `yield`
-        ["@keyword.return"] = vim.tbl_extend("force", { fg = theme.syn.special3 }, config.keywordStyle),
+        ["@keyword.return"] = vim.tbl_extend("force", { fg = theme.syn.special3 }, config.styles.keywords),
         -- @keyword.debug  (Debug)                            ; keywords related to debugging
         -- @keyword.exception (Exception)              ; keywords related to exceptions (e.g. `throw` / `catch`)
-        ["keyword.exception"] = vim.tbl_extend("force", { fg = theme.syn.special3 }, config.statementStyle),
+        ["keyword.exception"] = vim.tbl_extend("force", { fg = theme.syn.special3 }, config.styles.statements),
 
         ["@keyword.luap"] = { link = "@string.regex" },
 

--- a/lua/kanagawa/init.lua
+++ b/lua/kanagawa/init.lua
@@ -9,11 +9,13 @@ local M = {}
 ---@class KanagawaConfig
 M.config = {
     undercurl = true,
-    commentStyle = { italic = true },
-    functionStyle = {},
-    keywordStyle = { italic = true },
-    statementStyle = { bold = true },
-    typeStyle = {},
+    styles = {
+        comments = { italic = true },
+        functions = {},
+        keywords = { italic = true },
+        statements = { bold = true },
+        types = {},
+    },
     transparent = false,
     dimInactive = false,
     terminalColors = true,

--- a/lua/kanagawa/init.lua
+++ b/lua/kanagawa/init.lua
@@ -10,10 +10,15 @@ local M = {}
 M.config = {
     undercurl = true,
     styles = {
+        booleans = { bold = true },
+        builtinVariables = { italic = true },
         comments = { italic = true },
         functions = {},
         keywords = { italic = true },
+        operators = { bold = true },
+        readonlyFunctions = { bold = true },
         statements = { bold = true },
+        stringEscapes = { bold = true },
         types = {},
     },
     transparent = false,


### PR DESCRIPTION
This adds some style options, making the use of bold and italic text configurable for code syntax. Though I don't love some of the names I came up with for the additional options; I'm open to alternatives that are shorter and/or more descriptive.

Closes #176