### PR TITLE
Update editor.lua

### DIFF
--- a/lua/kanagawa/highlights/editor.lua
+++ b/lua/kanagawa/highlights/editor.lua
@@ -153,6 +153,12 @@ function M.setup(colors, config)
         DiagnosticHint = { fg = theme.diag.hint },
         DiagnosticOk = { fg = theme.diag.ok },
 
+        DiagnosticFloatingError = { fg = theme.diag.error },
+        DiagnosticFloatingWarn = { fg = theme.diag.warning },
+        DiagnosticFloatingInfo = { fg = theme.diag.info },
+        DiagnosticFloatingHint = { fg = theme.diag.hint },
+        DiagnosticFloatingOk = { fg = theme.diag.ok },
+
         DiagnosticSignError = { fg = theme.diag.error, bg = theme.ui.bg_gutter },
         DiagnosticSignWarn = { fg = theme.diag.warning, bg = theme.ui.bg_gutter },
         DiagnosticSignInfo = { fg = theme.diag.info, bg = theme.ui.bg_gutter },


### PR DESCRIPTION
Define the new `DiagnosticFloating*` highlight groups so that foreground colors are correctlly shown in floating LSP diagnostic windows (https://github.com/neovim/neovim/issues/26369#issuecomment-1838220782). If not, Neovim reverts to the (recently introduced) default colorscheme.

See before and after screenshots:

![before](https://github.com/rebelot/kanagawa.nvim/assets/37420199/2f06163e-6300-42e4-9649-6bdc13a1d0a6)

![after](https://github.com/rebelot/kanagawa.nvim/assets/37420199/c48b28bb-4969-4077-a21e-23aff8fd1ff6)
