### PR TITLE
fix: LspInfo border

### DIFF
--- a/lua/kanagawa/highlights/editor.lua
+++ b/lua/kanagawa/highlights/editor.lua
@@ -170,6 +170,7 @@ function M.setup(colors, config)
 
         LspSignatureActiveParameter = { fg = theme.diag.warning },
         LspCodeLens = { fg = theme.syn.comment },
+        LspInfoBorder = { fg = theme.ui.float.fg_border, bg = theme.ui.float.bg_border },
 
         -- vcs
         diffAdded = { fg = theme.vcs.added },


### PR DESCRIPTION
This border is not set in this theme and is defaulting to purple which is inconsistent with other floating window borders in this theme.

Adding a border to the `:LspInfo` floating window can be accomplished with 

```lua
require('lspconfig.ui.windows').default_options.border = 'rounded'
```
https://github.com/neovim/nvim-lspconfig/blob/eb81c7ea08d6f01d5fa4cf09e58c708efadf9b2f/doc/lspconfig.txt#L641