### PR TITLE
Add foot light theme and add CSD configuration on dark theme

### DIFF
--- a/extras/foot_kanagawa.ini
+++ b/extras/foot_kanagawa.ini
@@ -25,3 +25,7 @@ bright7  = dcd7ba
 
 16       = ffa066
 17       = ff5d62
+
+[csd]
+color = ff1f1f28
+button-color = ffdcd7ba

--- a/extras/foot_kanagawa_light.ini
+++ b/extras/foot_kanagawa_light.ini
@@ -1,0 +1,31 @@
+[colors]
+foreground = 545464
+background = f2ecbc
+
+selection-foreground = 43436c
+selection-background = c9cbd1
+
+regular0 = 1F1F28
+regular1 = c84053
+regular2 = 6f894e
+regular3 = 77713f
+regular4 = 4d699b
+regular5 = b35b79
+regular6 = 597b75
+regular7 = 545464
+
+bright0 = 8a8980
+bright1 = d7474b
+bright2 = 6e915f
+bright3 = 836f4a
+bright4 = 6693bf
+bright5 = 624c83
+bright6 = 5e857a
+bright7 = 43436c
+
+16 = cc6d00
+17 = e82424
+
+[csd]
+color = fff2ecbc
+button-color = ff545464


### PR DESCRIPTION
Noticed the light variant was missing a foot configuration. The CSD section is used by default on f.ex Gnome. The added CSD section to the dark theme makes foot look much better on Gnome, as the default was a white titlebar.