### PR TITLE
Add kanagawa_dragon.itermcolors link

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ The colors maintain a `4.5:1` contrast ratio, complying with [WCAG 2.1 | Level A
 - [fish](extras/kanagawa.fish)
 - [foot](extras/foot_kanagawa.ini)
 - [iTerm](extras/kanagawa.itermcolors)
+- [iTerm kanagawa_dragon](extras/kanagawa_dragon.itermcolors)
 - [kitty](extras/kanagawa.conf)
 - [mintty](extras/kanagawa.minttyrc)
 - [pywal](extras/pywal-theme.json)


### PR DESCRIPTION
## issue
When setting up the theme, I wanted to add the dragon theme to iterm. README only linked Kanagawa and made me think only Kanagawa was setup. I had to search through issues to find link to dragon theme

## what was done
Added link for dragon iterm theme in repo to readme to allow users to quickly find iterm theme.