### PR TITLE
feat(extras): add cmus theme

### DIFF
--- a/extras/kanagawa.theme
+++ b/extras/kanagawa.theme
@@ -1,0 +1,62 @@
+### colors
+### {{{
+
+# where you type your commands
+set color_cmdline_fg=187
+set color_cmdline_bg=default
+
+# the vertical line on the main window
+set color_separator=232
+
+# this displays how much time there is left from the song
+set color_statusline_bg=default
+set color_statusline_fg=103
+
+# the songs title is displayed here
+set color_titleline_bg=234
+set color_titleline_fg=180
+
+# the colors of the main window
+set color_win_bg=default
+set color_win_fg=111
+
+# color of the active entries when not selected
+set color_win_cur=180
+
+# maybe sets the colors of a different layout?
+set color_win_dir=180
+
+# color of the inactive songnames
+set color_win_fg=187
+
+### ---- settings for the INACTIVE window ---- ###
+
+# the played entries colors when selected
+set color_win_inactive_cur_sel_bg=234
+set color_win_inactive_cur_sel_fg=111
+
+# the inactive entries colors when selected
+set color_win_inactive_sel_bg=234
+set color_win_inactive_sel_fg=066
+
+### ---- settings for the ACTIVE window ---- ###
+
+# the played entries color when selected
+set color_win_cur_sel_bg=234
+set color_win_cur_sel_fg=180
+
+#  the inactive entries color when selected
+set color_win_sel_bg=234
+set color_win_sel_fg=111
+
+# --- END -- #
+
+# these set the colors of the titlebar at the top of the window
+set color_win_title_bg=234
+set color_win_title_fg=180
+
+# textcolor in commandbar (error(red) and info(green))
+set color_error=131
+set color_info=187
+
+### }}}


### PR DESCRIPTION
hi there,

this PR adds my kanagawa theme for cmus.

this is how it looks like:

![Screenshot from 2024-03-21 11-03-47](https://github.com/rebelot/kanagawa.nvim/assets/41571384/1583da54-2127-4046-8667-cb62fec30f1a)
