### PR TITLE
feat(extras): add alacritty kanagawa lotus theme

### DIFF
--- a/extras/alacritty_kanagawa_lotus.toml
+++ b/extras/alacritty_kanagawa_lotus.toml
@@ -1,0 +1,33 @@
+[colors.bright]
+black = "#8a8980"
+blue = "#6693bf"
+cyan = "#5e857a"
+green = "#6e915f"
+magenta = "#624c83"
+red = "#d7474b"
+white = "#43436c"
+yellow = "#836f4a"
+
+[colors.normal]
+black = "#1F1F28"
+blue = "#4d699b"
+cyan = "#597b75"
+green = "#6f894e"
+magenta = "#b35b79"
+red = "#c84053"
+white = "#545464"
+yellow = "#77713f"
+
+[colors.primary]
+background = "#f2ecbc"
+foreground = "#545464"
+dim_foreground = "#545464"
+bright_foreground = "#545464"
+
+[[colors.indexed_colors]]
+index = 16
+color = "#e98a00"
+
+[[colors.indexed_colors]]
+index = 17
+color = "#e82424"


### PR DESCRIPTION
### Background
since `alacritty` now supports original hex color code and doesn't need to be translated into `0x` part we can easily transform `themes` to the config. it seems people slightly not attracted to light theme, which is I liked the most and kanagawa *lotus* is the best (thanks for the amazing theme @rebelot and all of you!), these are some screens with `msgcat --color=test`.

### Screens
![Screenshot 2024-03-22 at 8 52 59 PM](https://github.com/rebelot/kanagawa.nvim/assets/1876018/ebaa44d8-53b9-459f-b0c6-bd28e16eb983)
![Screenshot 2024-03-22 at 8 52 46 PM](https://github.com/rebelot/kanagawa.nvim/assets/1876018/44949cf5-7dd1-4dfe-8132-77abd1f9e6ba)
![Screenshot 2024-03-22 at 8 52 31 PM](https://github.com/rebelot/kanagawa.nvim/assets/1876018/09d3b84e-af27-4b28-b841-20a676606d15)
![Screenshot 2024-03-22 at 8 52 23 PM](https://github.com/rebelot/kanagawa.nvim/assets/1876018/47a5257b-8e13-44d9-8ba4-e3f081ed8613)

---
well with `nvim` you guys already can try it with just `:colorscheme` change!
