### PR TITLE
feat(extras): add kanagawa_light.itermcolors

### DIFF
--- a/extras/kanagawa_light.itermcolors
+++ b/extras/kanagawa_light.itermcolors
@@ -1,0 +1,266 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Background Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.9490196078431372</real>
+        <key>Green Component</key>
+        <real>0.9254901960784314</real>
+        <key>Blue Component</key>
+        <real>0.7372549019607844</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Foreground Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.32941176470588235</real>
+        <key>Green Component</key>
+        <real>0.32941176470588235</real>
+        <key>Blue Component</key>
+        <real>0.39215686274509803</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Bold Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.45098039215686275</real>
+        <key>Green Component</key>
+        <real>0.6549019607843137</real>
+        <key>Blue Component</key>
+        <real>0.7372549019607844</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Cursor Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.2627450980392157</real>
+        <key>Green Component</key>
+        <real>0.2627450980392157</real>
+        <key>Blue Component</key>
+        <real>0.4235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 0 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.12156862745098039</real>
+        <key>Green Component</key>
+        <real>0.12156862745098039</real>
+        <key>Blue Component</key>
+        <real>0.1568627450980392</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 1 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.7843137254901961</real>
+        <key>Green Component</key>
+        <real>0.25098039215686274</real>
+        <key>Blue Component</key>
+        <real>0.3254901960784314</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 2 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.43529411764705883</real>
+        <key>Green Component</key>
+        <real>0.5372549019607843</real>
+        <key>Blue Component</key>
+        <real>0.3058823529411765</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 3 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.4666666666666667</real>
+        <key>Green Component</key>
+        <real>0.44313725490196076</real>
+        <key>Blue Component</key>
+        <real>0.24705882352941178</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 4 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.30196078431372547</real>
+        <key>Green Component</key>
+        <real>0.4117647058823529</real>
+        <key>Blue Component</key>
+        <real>0.6078431372549019</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 5 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.7019607843137254</real>
+        <key>Green Component</key>
+        <real>0.3568627450980392</real>
+        <key>Blue Component</key>
+        <real>0.4745098039215686</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 6 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.34901960784313724</real>
+        <key>Green Component</key>
+        <real>0.4823529411764706</real>
+        <key>Blue Component</key>
+        <real>0.4588235294117647</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 7 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.32941176470588235</real>
+        <key>Green Component</key>
+        <real>0.32941176470588235</real>
+        <key>Blue Component</key>
+        <real>0.39215686274509803</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 8 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.5411764705882353</real>
+        <key>Green Component</key>
+        <real>0.5372549019607843</real>
+        <key>Blue Component</key>
+        <real>0.5019607843137255</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 9 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.8431372549019608</real>
+        <key>Green Component</key>
+        <real>0.2784313725490196</real>
+        <key>Blue Component</key>
+        <real>0.29411764705882354</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 10 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.43137254901960786</real>
+        <key>Green Component</key>
+        <real>0.5686274509803921</real>
+        <key>Blue Component</key>
+        <real>0.37254901960784315</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 11 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.5137254901960784</real>
+        <key>Green Component</key>
+        <real>0.43529411764705883</real>
+        <key>Blue Component</key>
+        <real>0.2901960784313726</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 12 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.4</real>
+        <key>Green Component</key>
+        <real>0.5764705882352941</real>
+        <key>Blue Component</key>
+        <real>0.7490196078431373</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 13 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.3843137254901961</real>
+        <key>Green Component</key>
+        <real>0.2980392156862745</real>
+        <key>Blue Component</key>
+        <real>0.5137254901960784</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 14 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.3686274509803922</real>
+        <key>Green Component</key>
+        <real>0.5215686274509804</real>
+        <key>Blue Component</key>
+        <real>0.47843137254901963</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+    <key>Ansi 15 Color</key>
+    <dict>
+        <key>Red Component</key>
+        <real>0.2627450980392157</real>
+        <key>Green Component</key>
+        <real>0.2627450980392157</real>
+        <key>Blue Component</key>
+        <real>0.4235294117647059</real>
+        <key>Alpha Component</key>
+        <real>1</real>
+        <key>Color Space</key>
+        <string>sRGB</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
Kanagawa light theme for iTerm2.
<img width="787" alt="iterm-light" src="https://github.com/rebelot/kanagawa.nvim/assets/134519958/eb478253-20ba-4aa8-960d-470901e1fc68">
