### PR TITLE
Add hint on tinting diagnostic messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,27 @@ overrides = function(colors)
 end,
 ```
 
+#### Tint background of diagnostic messages with their foreground color
+
+This immitates a style of diagnostic messages seen, for example, in [tokyonight.nvim](https://github.com/folke/tokyonight.nvim).
+
+```lua
+overrides = function(colors)
+  local theme = colors.theme
+  local makeDiagnosticColor = function(color)
+    local c = require("kanagawa.lib.color")
+    return { fg = color, bg = c(color):blend(theme.ui.bg, 0.95):to_hex() }
+  end
+
+  return {
+    DiagnosticVirtualTextHint  = makeDiagnosticColor(theme.diag.hint),
+    DiagnosticVirtualTextInfo  = makeDiagnosticColor(theme.diag.info),
+    DiagnosticVirtualTextWarn  = makeDiagnosticColor(theme.diag.warning),
+    DiagnosticVirtualTextError = makeDiagnosticColor(theme.diag.error),
+  }
+end
+```
+
 ## Integration
 
 ### Get palette and theme colors


### PR DESCRIPTION
Thanks for this awesome theme!
@rebelot, I stumbled upon https://github.com/rebelot/kanagawa.nvim/issues/220 and [loved your solution there](https://github.com/rebelot/kanagawa.nvim/issues/220#issuecomment-2012456576) using the built-in kanagawa's functions. I figured it might be a good addition to the "Common customizations" section of the README. I've seen this style in other themes (including the very popular tokyonight), so it might be a customization that others might be looking for as well.

I've slightly refactored the code to extract the common logic to a callback.