### PR TITLE
Add common customization for treesitter-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,20 @@ colors = {
 }
 ```
 
+#### Add _gutter_ indications for treesitter-context.
+
+Italicize and dim the background of line numbers that belong to the [treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context/) context.
+
+```lua
+overrides = function(colors)
+    local theme = colors.theme
+    return {
+          -- Dim gutter background for treesitter-context line numbers
+          TreesitterContextLineNumber = { bg = theme.ui.bg_dim, fg = theme.ui.nontext, italic = true }
+    }
+end,
+```
+
 #### Transparent Floating Windows
 
 This will make floating windows look nicer with default borders.


### PR DESCRIPTION
Since the theme supports `treesitter` extensively, I thought it'd be nice to include a common customization to make the `treesitter-context` context lines stand out a little more.

Preview of what this customization does: 

Pre:
![image](https://github.com/rebelot/kanagawa.nvim/assets/8700780/655e0a16-d3ff-465e-bb5d-b8fc6697ec7f)

Post:
![image](https://github.com/rebelot/kanagawa.nvim/assets/8700780/acee46f0-bad5-4c3a-8d07-67977b0b5260)

Since it uses `theme` colors it should work nicely on any variant.