### PR TITLE
Fix missing "@" for @keyword.exception

### DIFF
--- a/lua/kanagawa/highlights/treesitter.lua
+++ b/lua/kanagawa/highlights/treesitter.lua
@@ -80,7 +80,7 @@ function M.setup(colors, config)
         ["@keyword.return"] = vim.tbl_extend("force", { fg = theme.syn.special3 }, config.keywordStyle),
         -- @keyword.debug          keywords related to debugging
         -- @keyword.exception      keywords related to exceptions (e.g. `throw`, `catch`)
-        ["keyword.exception"] = vim.tbl_extend("force", { fg = theme.syn.special3 }, config.statementStyle),
+        ["@keyword.exception"] = vim.tbl_extend("force", { fg = theme.syn.special3 }, config.statementStyle),
 
         ["@keyword.luap"] = { link = "@string.regex" },
         --


### PR DESCRIPTION
The `@keyword.exception` highlight group was missing the `@` symbol. This PR adds it to match the other keyword groups and to match what [treesitter uses](https://github.com/nvim-treesitter/nvim-treesitter/blob/488e39a8f1fcb7935deaaf1852e3d6c28ca253d0/CONTRIBUTING.md#keywords).

Love this theme!