### PR TITLE
Add instructions on configuring a transparent telescope and setup automatic compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,39 @@ overrides = function(colors)
 end,
 ```
 
+#### Transparent Telescope
+
+Fully transparent telescope UI with borders
+
+Completely removes telescope background leaving only borders
+
+If there is a need to run `:KanagawaCompile` everytime on startup for settings to take place, consider automatic compilation (automatic compilation setup can be found below)
+
+```lua
+overrides = function(colors)
+    local theme = colors.theme
+    return {
+          TelescopeTitle = { fg = theme.ui.special, bold = true },
+          TelescopePromptNormal = { bg = "none" },
+          TelescopePromptBorder = { fg = "none", bg = "none" },
+          TelescopeResultsNormal = { fg = "none", bg = "none" },
+          TelescopeResultsBorder = { fg = "none", bg = "none" },
+          TelescopePreviewNormal = { bg = "none" },
+          TelescopePreviewBorder = { bg = "none", fg = "none" },
+    }
+end,
+```
+
+Place the following into `init.lua` for auto compilation
+
+```lua
+vim.api.nvim_create_autocmd("VimEnter", {
+  callback = function()
+    vim.cmd("KanagawaCompile")
+  end,
+})
+```
+
 #### Dark completion (popup) menu
 
 More uniform colors for the popup menu.
@@ -349,7 +382,7 @@ vim.api.nvim_create_autocmd("ColorScheme", {
 
 ## Accessibility
 
-The colors maintain a `4.5:1` contrast ratio, complying with [WCAG 2.1 | Level AA](https://www.w3.org/TR/WCAG21/#contrast-minimum).  
+The colors maintain a `4.5:1` contrast ratio, complying with [WCAG 2.1 | Level AA](https://www.w3.org/TR/WCAG21/#contrast-minimum).
 
 ## Extras
 

--- a/README.md
+++ b/README.md
@@ -254,8 +254,6 @@ end,
 
 #### Transparent Telescope
 
-Fully transparent telescope UI with borders
-
 Completely removes telescope background leaving only borders
 
 If there is a need to run `:KanagawaCompile` everytime on startup for settings to take place, consider automatic compilation (automatic compilation setup can be found below)


### PR DESCRIPTION
**Added instructions on how to configure the following telescope menu**

<img width="1798" alt="Screenshot 2024-07-18 at 4 13 48 PM" src="https://github.com/user-attachments/assets/7bf49073-9aa8-4527-b238-481e1c24b6af">

The setting does not work unless `:KanagawaCompile` is being run every time an instance of nvim is being started, so instructions to an automatic compilation is also included.

Telescope menu without automatic compilation
<img width="1798" alt="Screenshot 2024-07-18 at 4 22 30 PM" src="https://github.com/user-attachments/assets/e4efb596-71cb-47a5-99cf-318631b11199">

