### PR TITLE
feat(terminal): added kanagawa themes for ghostty

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,22 +106,27 @@ Themes can be changed in three ways:
   Any change to the value of `vim.o.background` will select the theme mapped by `config.background`.
   Use `vim.o.background = ""` to unset this option.
   You can thus map the value of `vim.o.background` to all three kanagawa variants:
+
   ```lua
     {
         ...
         theme = "wave",              -- vim.o.background = ""
-        background = {               
+        background = {
             dark = "dragon",         -- vim.o.background = "dark"
             light = "lotus"          -- vim.o.background = "light"
     }
   ```
+
 - Loading the colorscheme directly with:
+
   ```lua
   vim.cmd("colorscheme kanagawa-wave")
   vim.cmd("colorscheme kanagawa-dragon")
   vim.cmd("colorscheme kanagawa-lotus")
   ```
+
   or
+
   ```lua
   require("kanagawa").load("wave")
   ```
@@ -380,7 +385,7 @@ vim.api.nvim_create_autocmd("ColorScheme", {
 
 ## Accessibility
 
-The colors maintain a `4.5:1` contrast ratio, complying with [WCAG 2.1 | Level AA](https://www.w3.org/TR/WCAG21/#contrast-minimum).  
+The colors maintain a `4.5:1` contrast ratio, complying with [WCAG 2.1 | Level AA](https://www.w3.org/TR/WCAG21/#contrast-minimum).
 
 ## Extras
 
@@ -398,6 +403,7 @@ The colors maintain a `4.5:1` contrast ratio, complying with [WCAG 2.1 | Level A
 - [Sway](extras/sway/)
 - [Wezterm](extras/wezterm/)
 - [Windows Terminal](extras/windows_terminal/)
+- [Ghostty](extras/ghostty)
 - [Xresources](extras/xresources/)
 - [tmTheme (Sublime Text, bat and delta)](extras/textmate/)
 - [JSON compatible with many terminals](extras/gogh/) Check [Gogh](https://github.com/Gogh-Co/Gogh#-terminals) for the list of supported terminals.

--- a/extras/ghostty/kanagawa-dragon
+++ b/extras/ghostty/kanagawa-dragon
@@ -1,0 +1,22 @@
+palette = 0=#0d0c0c
+palette = 1=#c4746e
+palette = 2=#8a9a7b
+palette = 3=#c4b28a
+palette = 4=#8ba4b0
+palette = 5=#a292a3
+palette = 6=#8ea4a2
+palette = 7=#c8c093
+palette = 8=#a6a69c
+palette = 9=#e46876
+palette = 10=#87a987
+palette = 11=#e6c384
+palette = 12=#7fb4ca
+palette = 13=#938aa9
+palette = 14=#7aa89f
+palette = 15=#c5c9c5
+
+background = 181616
+foreground = c5c9c5
+cursor-color = c8c093
+selection-background = 2d4f67
+selection-foreground = c8c093

--- a/extras/ghostty/kanagawa-lotus
+++ b/extras/ghostty/kanagawa-lotus
@@ -1,0 +1,22 @@
+palette = 0=#1f1f28
+palette = 1=#c84053
+palette = 2=#6f894e
+palette = 3=#77713f
+palette = 4=#4d699b
+palette = 5=#b35b79
+palette = 6=#597b75
+palette = 7=#545464
+palette = 8=#8a8980
+palette = 9=#d7474b
+palette = 10=#6e915f
+palette = 11=#836f4a
+palette = 12=#6693bf
+palette = 13=#624c83
+palette = 14=#5e857a
+palette = 15=#43436c
+
+background = f2ecbc
+foreground = 545464
+cursor-color = 43436c
+selection-background = c9cbd1
+selection-foreground = 43436c

--- a/extras/ghostty/kanagawa-wave
+++ b/extras/ghostty/kanagawa-wave
@@ -1,0 +1,23 @@
+palette = 0=#16161d
+palette = 1=#c34043
+palette = 2=#76946a
+palette = 3=#c0a36e
+palette = 4=#7e9cd8
+palette = 5=#957fb8
+palette = 6=#6a9589
+palette = 7=#c8c093
+palette = 8=#727169
+palette = 9=#e82424
+palette = 10=#98bb6c
+palette = 11=#e6c384
+palette = 12=#7fb4ca
+palette = 13=#938aa9
+palette = 14=#7aa89f
+palette = 15=#dcd7ba
+
+background = 1f1f28
+foreground = dcd7ba
+cursor-color = c8c093
+selection-background = 2d4f67
+selection-foreground = c8c093
+


### PR DESCRIPTION
I have added the three kanagawa themes (dragon, wave and lotus) for ghostty.

PS: it follows the same structure as in this [PR](#269)