### PR TITLE
add kanagawa theme extra for AwesomeWM

### DIFF
--- a/extras/awesome/kanagawa.lua
+++ b/extras/awesome/kanagawa.lua
@@ -1,0 +1,256 @@
+-- Palette from Kanagawa.nvim
+-- ( https://github.com/rebelot/kanagawa.nvim )
+local palette = {
+
+	-- Bg Shades
+	sumiInk0 = "#16161D",
+	sumiInk1 = "#181820",
+	sumiInk2 = "#1a1a22",
+	sumiInk3 = "#1F1F28",
+	sumiInk4 = "#2A2A37",
+	sumiInk5 = "#363646",
+	sumiInk6 = "#54546D", --fg
+
+	-- Popup and Floats
+	waveBlue1 = "#223249",
+	waveBlue2 = "#2D4F67",
+
+	-- Diff and Git
+	winterGreen = "#2B3328",
+	winterYellow = "#49443C",
+	winterRed = "#43242B",
+	winterBlue = "#252535",
+	autumnGreen = "#76946A",
+	autumnRed = "#C34043",
+	autumnYellow = "#DCA561",
+
+	-- Diag
+	samuraiRed = "#E82424",
+	roninYellow = "#FF9E3B",
+	waveAqua1 = "#6A9589",
+	dragonBlue = "#658594",
+
+	-- Fg and Comments
+	oldWhite = "#C8C093",
+	fujiWhite = "#DCD7BA",
+	fujiGray = "#727169",
+
+	oniViolet = "#957FB8",
+	oniViolet2 = "#b8b4d0",
+	crystalBlue = "#7E9CD8",
+	springViolet1 = "#938AA9",
+	springViolet2 = "#9CABCA",
+	springBlue = "#7FB4CA",
+	lightBlue = "#A3D4D5", -- unused yet
+	waveAqua2 = "#7AA89F", -- improve lightness: desaturated greenish Aqua
+
+	-- waveAqua2  = "#68AD99",
+	-- waveAqua4  = "#7AA880",
+	-- waveAqua5  = "#6CAF95",
+	-- waveAqua3  = "#68AD99",
+
+	springGreen = "#98BB6C",
+	boatYellow1 = "#938056",
+	boatYellow2 = "#C0A36E",
+	carpYellow = "#E6C384",
+
+	sakuraPink = "#D27E99",
+	waveRed = "#E46876",
+	peachRed = "#FF5D62",
+	surimiOrange = "#FFA066",
+	katanaGray = "#717C7C",
+
+	dragonBlack0 = "#0d0c0c",
+	dragonBlack1 = "#12120f",
+	dragonBlack2 = "#1D1C19",
+	dragonBlack3 = "#181616",
+	dragonBlack4 = "#282727",
+	dragonBlack5 = "#393836",
+	dragonBlack6 = "#625e5a",
+
+	dragonWhite = "#c5c9c5",
+	dragonGreen = "#87a987",
+	dragonGreen2 = "#8a9a7b",
+	dragonPink = "#a292a3",
+	dragonOrange = "#b6927b",
+	dragonOrange2 = "#b98d7b",
+	dragonGray = "#a6a69c",
+	dragonGray2 = "#9e9b93",
+	dragonGray3 = "#7a8382",
+	dragonBlue2 = "#8ba4b0",
+	dragonViolet = "#8992a7",
+	dragonRed = "#c4746e",
+	dragonAqua = "#8ea4a2",
+	dragonAsh = "#737c73",
+	dragonTeal = "#949fb5",
+	dragonYellow = "#c4b28a", --"#a99c8b",
+	-- "#8a9aa3",
+
+	lotusInk1 = "#545464",
+	lotusInk2 = "#43436c",
+	lotusGray = "#dcd7ba",
+	lotusGray2 = "#716e61",
+	lotusGray3 = "#8a8980",
+	lotusWhite0 = "#d5cea3",
+	lotusWhite1 = "#dcd5ac",
+	lotusWhite2 = "#e5ddb0",
+	lotusWhite3 = "#f2ecbc",
+	lotusWhite4 = "#e7dba0",
+	lotusWhite5 = "#e4d794",
+	lotusViolet1 = "#a09cac",
+	lotusViolet2 = "#766b90",
+	lotusViolet3 = "#c9cbd1",
+	lotusViolet4 = "#624c83",
+	lotusBlue1 = "#c7d7e0",
+	lotusBlue2 = "#b5cbd2",
+	lotusBlue3 = "#9fb5c9",
+	lotusBlue4 = "#4d699b",
+	lotusBlue5 = "#5d57a3",
+	lotusGreen = "#6f894e",
+	lotusGreen2 = "#6e915f",
+	lotusGreen3 = "#b7d0ae",
+	lotusPink = "#b35b79",
+	lotusOrange = "#cc6d00",
+	lotusOrange2 = "#e98a00",
+	lotusYellow = "#77713f",
+	lotusYellow2 = "#836f4a",
+	lotusYellow3 = "#de9800",
+	lotusYellow4 = "#f9d791",
+	lotusRed = "#c84053",
+	lotusRed2 = "#d7474b",
+	lotusRed3 = "#e82424",
+	lotusRed4 = "#d9a594",
+	lotusAqua = "#597b75",
+	lotusAqua2 = "#5e857a",
+	lotusTeal1 = "#4e8ca2",
+	lotusTeal2 = "#6693bf",
+	lotusTeal3 = "#5a7785",
+	lotusCyan = "#d7e3d8",
+}
+
+---------------------------
+-- Default awesome theme --
+---------------------------
+-- (added Kanagawa palette and JetBrains Mono)
+
+local theme_assets = require("beautiful.theme_assets")
+local xresources = require("beautiful.xresources")
+local dpi = xresources.apply_dpi
+
+local gfs = require("gears.filesystem")
+local themes_path = gfs.get_themes_dir()
+
+local theme = {}
+
+theme.font = "JetBrains Mono 9"
+
+theme.bg_normal = palette.sumiInk2
+theme.bg_focus = palette.sumiInk5
+theme.bg_urgent = palette.roninYellow
+theme.bg_minimize = palette.sumiInk4
+theme.bg_systray = theme.bg_normal
+
+theme.fg_normal = "#aaaaaa"
+theme.fg_focus = "#ffffff"
+theme.fg_urgent = "#ffffff"
+theme.fg_minimize = "#ffffff"
+
+theme.useless_gap = dpi(0)
+theme.border_width = dpi(1)
+theme.border_normal = "#000000"
+theme.border_focus = "#535d6c"
+theme.border_marked = "#91231c"
+
+-- There are other variable sets
+-- overriding the default one when
+-- defined, the sets are:
+-- taglist_[bg|fg]_[focus|urgent|occupied|empty|volatile]
+-- tasklist_[bg|fg]_[focus|urgent]
+-- titlebar_[bg|fg]_[normal|focus]
+-- tooltip_[font|opacity|fg_color|bg_color|border_width|border_color]
+-- mouse_finder_[color|timeout|animate_timeout|radius|factor]
+-- prompt_[fg|bg|fg_cursor|bg_cursor|font]
+-- hotkeys_[bg|fg|border_width|border_color|shape|opacity|modifiers_fg|label_bg|label_fg|group_margin|font|description_font]
+-- Example:
+--theme.taglist_bg_focus = "#ff0000"
+
+-- Generate taglist squares:
+local taglist_square_size = dpi(4)
+theme.taglist_squares_sel = theme_assets.taglist_squares_sel(taglist_square_size, theme.fg_normal)
+theme.taglist_squares_unsel = theme_assets.taglist_squares_unsel(taglist_square_size, theme.fg_normal)
+
+-- Variables set for theming notifications:
+-- notification_font
+-- notification_[bg|fg]
+-- notification_[width|height|margin]
+-- notification_[border_color|border_width|shape|opacity]
+
+-- Variables set for theming the menu:
+-- menu_[bg|fg]_[normal|focus]
+-- menu_[border_color|border_width]
+theme.menu_submenu_icon = themes_path .. "default/submenu.png"
+theme.menu_height = dpi(25)
+theme.menu_width = dpi(200)
+
+-- You can add as many variables as
+-- you wish and access them by using
+-- beautiful.variable in your rc.lua
+--theme.bg_widget = "#cc0000"
+
+-- Define the image to load
+theme.titlebar_close_button_normal = themes_path .. "default/titlebar/close_normal.png"
+theme.titlebar_close_button_focus = themes_path .. "default/titlebar/close_focus.png"
+
+theme.titlebar_minimize_button_normal = themes_path .. "default/titlebar/minimize_normal.png"
+theme.titlebar_minimize_button_focus = themes_path .. "default/titlebar/minimize_focus.png"
+
+theme.titlebar_ontop_button_normal_inactive = themes_path .. "default/titlebar/ontop_normal_inactive.png"
+theme.titlebar_ontop_button_focus_inactive = themes_path .. "default/titlebar/ontop_focus_inactive.png"
+theme.titlebar_ontop_button_normal_active = themes_path .. "default/titlebar/ontop_normal_active.png"
+theme.titlebar_ontop_button_focus_active = themes_path .. "default/titlebar/ontop_focus_active.png"
+
+theme.titlebar_sticky_button_normal_inactive = themes_path .. "default/titlebar/sticky_normal_inactive.png"
+theme.titlebar_sticky_button_focus_inactive = themes_path .. "default/titlebar/sticky_focus_inactive.png"
+theme.titlebar_sticky_button_normal_active = themes_path .. "default/titlebar/sticky_normal_active.png"
+theme.titlebar_sticky_button_focus_active = themes_path .. "default/titlebar/sticky_focus_active.png"
+
+theme.titlebar_floating_button_normal_inactive = themes_path .. "default/titlebar/floating_normal_inactive.png"
+theme.titlebar_floating_button_focus_inactive = themes_path .. "default/titlebar/floating_focus_inactive.png"
+theme.titlebar_floating_button_normal_active = themes_path .. "default/titlebar/floating_normal_active.png"
+theme.titlebar_floating_button_focus_active = themes_path .. "default/titlebar/floating_focus_active.png"
+
+theme.titlebar_maximized_button_normal_inactive = themes_path .. "default/titlebar/maximized_normal_inactive.png"
+theme.titlebar_maximized_button_focus_inactive = themes_path .. "default/titlebar/maximized_focus_inactive.png"
+theme.titlebar_maximized_button_normal_active = themes_path .. "default/titlebar/maximized_normal_active.png"
+theme.titlebar_maximized_button_focus_active = themes_path .. "default/titlebar/maximized_focus_active.png"
+
+theme.wallpaper = "~/Pictures/wallpaper/codevogel-wallpaper.png"
+
+-- You can use your own layout icons like this:
+theme.layout_fairh = themes_path .. "default/layouts/fairhw.png"
+theme.layout_fairv = themes_path .. "default/layouts/fairvw.png"
+theme.layout_floating = themes_path .. "default/layouts/floatingw.png"
+theme.layout_magnifier = themes_path .. "default/layouts/magnifierw.png"
+theme.layout_max = themes_path .. "default/layouts/maxw.png"
+theme.layout_fullscreen = themes_path .. "default/layouts/fullscreenw.png"
+theme.layout_tilebottom = themes_path .. "default/layouts/tilebottomw.png"
+theme.layout_tileleft = themes_path .. "default/layouts/tileleftw.png"
+theme.layout_tile = themes_path .. "default/layouts/tilew.png"
+theme.layout_tiletop = themes_path .. "default/layouts/tiletopw.png"
+theme.layout_spiral = themes_path .. "default/layouts/spiralw.png"
+theme.layout_dwindle = themes_path .. "default/layouts/dwindlew.png"
+theme.layout_cornernw = themes_path .. "default/layouts/cornernww.png"
+theme.layout_cornerne = themes_path .. "default/layouts/cornernew.png"
+theme.layout_cornersw = themes_path .. "default/layouts/cornersww.png"
+theme.layout_cornerse = themes_path .. "default/layouts/cornersew.png"
+
+-- Generate Awesome icon:
+theme.awesome_icon = theme_assets.awesome_icon(theme.menu_height, theme.bg_focus, theme.fg_focus)
+
+-- Define the icon theme for application icons. If not set then the icons
+-- from /usr/share/icons and /usr/share/icons/hicolor will be used.
+theme.icon_theme = nil
+
+return theme
+
+-- vim: filetype=lua:expandtab:shiftwidth=4:tabstop=8:softtabstop=4:textwidth=80


### PR DESCRIPTION
Adds a `kanagawa.lua` to `/extras/` that incorporates the Kanagawa colors as a theme for AwesomeWM.

Takes the [default theme](https://awesomewm.org/doc/api/sample%20files/theme.lua.html) for AwesomeWM, grabs the [lua color table](https://raw.githubusercontent.com/rebelot/kanagawa.nvim/refs/heads/master/lua/kanagawa/colors.lua), and incorporates them.

Does not support the variants OOTB, but would allow easy alteration to include those colors instead.