### PR TITLE
fix(lsp): link @lsp.type.comment semantic token to Comment hlgroup

### DIFF
--- a/lua/kanagawa/highlights/lsp.lua
+++ b/lua/kanagawa/highlights/lsp.lua
@@ -20,7 +20,7 @@ function M.setup(colors, config)
         -- ["@lsp.type.type"] = { link = "Type" },
         -- ["@lsp.type.typeParameter"] = { link = "TypeDef" },
         ["@lsp.type.variable"] = { fg = "none" }, -- Identifier
-        ["@lsp.type.comment"] = { fg = "none" },  -- Comment
+        ["@lsp.type.comment"] = { link = "Comment" },  -- Comment
 
         ["@lsp.type.const"] = { link = "Constant" },
         ["@lsp.type.comparison"] = { link = "Operator" },


### PR DESCRIPTION
This commit ensures that LSP-identified comments are highlighted as comments. Previously, `{ fg = "none" }` was disabling any special highlighting for LSP-identified comments.

I believe this link is the default since 0.9 (here [default runtime/colors/vim.lua#L197](https://github.com/neovim/neovim/blob/56fabcadb6df46c70402e4f9cd1b851856fb57e9/runtime/colors/vim.lua#L197)).

I was bumping into this with preprocessor blocks in C code. With `fg = "none"`, inactive regions would not get any special highlighting but also wouldn't get de-emphasized (or grayed out like comments):

![image](https://github.com/user-attachments/assets/64ff8955-eff2-4424-be08-76ceda14b3cb)

With this commit, the unused block gets styled like any other comment:

![image](https://github.com/user-attachments/assets/3413b571-94e4-4945-af03-c693b912154b)
