### PR TITLE
make link urls underline not undercurl

### DIFF
--- a/lua/kanagawa/highlights/treesitter.lua
+++ b/lua/kanagawa/highlights/treesitter.lua
@@ -35,7 +35,7 @@ function M.setup(colors, config)
         ["@string.special.symbol"] = { fg = theme.syn.identifier },
         -- @string.special.path    filenames
         -- @string.special.url (Underlined)     URIs (e.g. hyperlinks)
-        ["@string.special.url"] = { fg = theme.syn.special1, undercurl = true },
+        ["@string.special.url"] = { fg = theme.syn.special1, underline = true },
         -- @character              character literals
         -- @character.special      special characters (e.g. wildcards)
         --


### PR DESCRIPTION
undercurl implies an error or warning, so a plain underline seems more appropriate