### PR TITLE
fix: Align `g:colors_name` with the theme names in `/colors`

### DIFF
--- a/lua/kanagawa/init.lua
+++ b/lua/kanagawa/init.lua
@@ -55,7 +55,7 @@ function M.load(theme)
         vim.cmd("hi clear")
     end
 
-    vim.g.colors_name = "kanagawa"
+    vim.g.colors_name = theme and "kanagawa-" .. theme or "kanagawa"
     vim.o.termguicolors = true
 
     if M.config.compile then


### PR DESCRIPTION
In this way, this variable will be useful for other plugins. https://github.com/xiyaowong/transparent.nvim/issues/81