### PR TITLE
feat: add fzf-lua plugin

### DIFF
--- a/lua/kanagawa/highlights/plugins.lua
+++ b/lua/kanagawa/highlights/plugins.lua
@@ -43,6 +43,18 @@ function M.setup(colors, config)
         TelescopeResultsField = { link = "@field" },
         TelescopeResultsMethod = { link = "Function" },
         TelescopeResultsVariable = { link = "@variable" },
+        -- FzfLua
+        FzfLuaHeaderBind = { fg = theme.syn.parameter }, -- *BlanchedAlmond
+        FzfLuaHeaderText = { fg = theme.syn.fun }, -- *Brown1
+        FzfLuaPathColNr = { fg = theme.syn.type }, -- *CadetBlue1
+        FzfLuaPathLineNr = { fg = theme.diag.ok }, -- *LightGreen
+        FzfLuaBufNr = { fg = theme.syn.parameter }, -- *BlanchedAlmond
+        FzfLuaBufFlagCur = { fg = theme.diag.ok }, -- *Brown1
+        FzfLuaBufFlagAlt = { fg = theme.syn.type }, -- *CadetBlue1
+        FzfLuaTabTitle = { fg = theme.diag.hint }, -- *LightSkyBlue1
+        FzfLuaTabMarker = { fg = theme.syn.parameter }, -- *BlanchedAlmond
+        FzfLuaLivePrompt = { fg = theme.syn.keyword }, -- *PaleVioletRed1
+        FzfLuaLiveSym = { fg = theme.syn.keyword }, -- *PaleVioletRed1
         -- NvimTree
         NvimTreeNormal = { link = "Normal" },
         NvimTreeNormalNC = { link = "NvimTreeNormal" },


### PR DESCRIPTION
I see that Telescope is not maintained anymore, so trying to move to fzf-lua plugin, but faced with some theme issues with it: Fzf-lua has some weird hardcoded values for some groups. Updated them to use values from theme.