### PR TITLE
fix: Changes vim.g.colours_name to reflect theme variants

### DIFF
--- a/lua/kanagawa/init.lua
+++ b/lua/kanagawa/init.lua
@@ -55,7 +55,7 @@ function M.load(theme)
         vim.cmd("hi clear")
     end
 
-    vim.g.colors_name = "kanagawa"
+    vim.g.colors_name = "kanagawa-" .. theme
     vim.o.termguicolors = true
 
     if M.config.compile then


### PR DESCRIPTION
Hi, this is my first time contributing to a repo. So I am not sure if what I am doing is correct.

This pull request just makes it so the `load` method appends the theme variants to the vim.g.colours_name. So subsequent reapplications calls the correct variant instead of the base.

This is done because some plugins that alter the highlight groups would apply the wrong variant due to the missing information. e.g. `xiyaowong/transparent.nvim`