### PR TITLE
feat(fish): add dragon theme to fish shell

### DIFF
--- a/extras/fish/kanagawa_dragon.fish
+++ b/extras/fish/kanagawa_dragon.fish
@@ -1,0 +1,37 @@
+#!/usr/bin/fish
+
+# Kanagawa Dragon Fish shell theme
+# A template was taken and modified from Tokyonight:
+# https://github.com/folke/tokyonight.nvim/blob/main/extras/fish_tokyonight_night.fish
+set -l foreground C5C9C5 normal
+set -l selection 2D4F67 brcyan
+set -l comment 737C73 brblack
+set -l red C4746E red
+set -l orange E46876 brred
+set -l yellow C4B28A yellow
+set -l green 8A9A7B green
+set -l purple A292A3 magenta
+set -l cyan 8EA4A2 cyan
+set -l pink 938AA9 brmagenta
+
+# Syntax Highlighting Colors
+set -g fish_color_normal $foreground
+set -g fish_color_command $cyan
+set -g fish_color_keyword $pink
+set -g fish_color_quote $yellow
+set -g fish_color_redirection $foreground
+set -g fish_color_end $orange
+set -g fish_color_error $red
+set -g fish_color_param $purple
+set -g fish_color_comment $comment
+set -g fish_color_selection --background=$selection
+set -g fish_color_search_match --background=$selection
+set -g fish_color_operator $green
+set -g fish_color_escape $pink
+set -g fish_color_autosuggestion $comment
+
+# Completion Pager Colors
+set -g fish_pager_color_progress $comment
+set -g fish_pager_color_prefix $cyan
+set -g fish_pager_color_completion $foreground
+set -g fish_pager_color_description $comment


### PR DESCRIPTION
The existing `kanagawa.fish` is likely for the wave variant, which clashes slightly if you are using the dragon variant for the rest of the colours.

The values in `kanagawa_dragon.fish` has been cross-checked with that in the `dragon` table in [themes.lua](https://github.com/rebelot/kanagawa.nvim/blob/master/lua/kanagawa/themes.lua) and that in the alacritty config [kanagawa_dragon.toml](https://github.com/rebelot/kanagawa.nvim/blob/master/extras/alacritty/kanagawa_dragon.toml).

Before (with `kanagawa.fish`, alacritty's dragon theme):
<img width="1280" height="350" alt="before" src="https://github.com/user-attachments/assets/ec38b54a-7603-4eba-9927-b4afcad602a9" />

After (with `kanagawa_dragon.fish`, alacritty's dragon theme):
<img width="1280" height="350" alt="after" src="https://github.com/user-attachments/assets/a54faee9-6cc9-4525-8ee4-4085470dcac2" />
