### PR TITLE
Change kitty tab backgrounds to not be black

### DIFF
--- a/extras/kitty/kanagawa.conf
+++ b/extras/kitty/kanagawa.conf
@@ -14,9 +14,9 @@ url_color #72A7BC
 cursor #C8C093
 
 # Tabs
-active_tab_background #1F1F28
+active_tab_background #2D4F67
 active_tab_foreground #C8C093
-inactive_tab_background  #1F1F28
+inactive_tab_background  #223249
 inactive_tab_foreground #727169
 #tab_bar_background #15161E
 

--- a/extras/kitty/kanagawa_dragon.conf
+++ b/extras/kitty/kanagawa_dragon.conf
@@ -14,9 +14,9 @@ url_color #72A7BC
 cursor #C8C093
 
 # Tabs
-active_tab_background #12120f
+active_tab_background #2D4F67
 active_tab_foreground #C8C093
-inactive_tab_background  #12120f
+inactive_tab_background  #223249
 inactive_tab_foreground #a6a69c
 #tab_bar_background #15161E
 


### PR DESCRIPTION
I found that using the popup backgrounds allowed me to actually see the
tabs. If this is too much of a personal preference thing and I'm the
only one that wants to contrast the tab line from the rest of the
terminal, then this can be closed.
