### PR TITLE
Add Helix themes

### DIFF
--- a/extras/helix/kanagawa-dragon.toml
+++ b/extras/helix/kanagawa-dragon.toml
@@ -1,0 +1,249 @@
+# Syntax highlighting
+# -------------------
+"attribute" = "dragonOrange"
+
+"type" = "dragonAqua"
+"type.builtin" = "dragonAqua"
+"type.enum.variant" = "dragonAqua"
+
+"constructor" = "dragonTeal"
+
+"constant" = "dragonOrange"
+"constant.numeric" = "dragonPink"
+"constant.character" = "dragonGreen2"
+"constant.character.escape" = "dragonRed"
+
+"string" = "dragonGreen2"
+"string.regexp" = "dragonRed"
+"string.special" = "dragonTeal"
+"string.special.symbol" = "dragonYellow"
+"string.special.url" = { fg = "dragonTeal", underline = { color = "dragonTeal", style = "curl" } }
+
+"comment" = { fg = "dragonAsh", modifiers = ["italic"] }
+
+"variable" = "dragonWhite"
+"variable.parameter" = "dragonGray"
+"variable.builtin" = "dragonRed"
+"variable.other.member" = "dragonYellow"
+
+"label" = "dragonTeal"
+
+"punctuation" = "dragonGray2"
+"punctuation.special" = "dragonTeal"
+
+"keyword" = { fg = "dragonViolet", modifiers = ["italic"] }
+"keyword.control.conditional" = { fg = "dragonViolet", modifiers = ["italic"] }
+"keyword.control.import" = { fg = "dragonViolet", modifiers = ["italic"] }
+"keyword.control.return" = { fg = "dragonRed", modifiers = ["italic"] }
+"keyword.control.exception" = { fg = "dragonRed", modifiers = ["bold"] }
+"keyword.function" = { fg = "dragonViolet", modifiers = ["italic"] }
+"keyword.directive" = "dragonRed"
+"keyword.directive.define" = "dragonRed"
+"keyword.operator" = { fg = "dragonRed", modifiers = ["bold"] }
+
+"operator" = "dragonRed"
+
+"function" = "dragonBlue2"
+"function.macro" = "dragonRed"
+
+"tag" = "dragonBlue2"
+
+"namespace" = "dragonYellow"
+
+"special" = "dragonTeal"
+
+"markup.heading" = "dragonBlue2"
+"markup.heading.1" = "dragonBlue2"
+"markup.heading.2" = "dragonBlue2"
+"markup.heading.3" = "dragonBlue2"
+"markup.heading.4" = "dragonBlue2"
+"markup.heading.5" = "dragonBlue2"
+"markup.heading.6" = "dragonBlue2"
+"markup.list" = "dragonTeal"
+"markup.list.unchecked" = "dragonBlack6"
+"markup.list.checked" = "dragonGreen2"
+"markup.bold" = { fg = "dragonRed", modifiers = ["bold"] }
+"markup.italic" = { fg = "dragonRed", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.underline" = { modifiers = ["underlined"] }
+"markup.link.url" = { fg = "dragonTeal", underline = { color = "dragonTeal", style = "curl" } }
+"markup.link.text" = "dragonViolet"
+"markup.link.label" = "dragonYellow"
+"markup.raw" = "dragonGreen2"
+"markup.quote" = "dragonGray"
+
+"diff.plus" = "autumnGreen"
+"diff.minus" = "autumnRed"
+"diff.delta" = "autumnYellow"
+
+# User Interface
+# --------------
+"ui.background" = { fg = "dragonWhite", bg = "dragonBlack3" }
+
+"ui.linenr" = { fg = "dragonBlack6" }
+"ui.linenr.selected" = { fg = "roninYellow" }
+
+"ui.statusline" = { fg = "oldWhite", bg = "dragonBlack0" }
+"ui.statusline.inactive" = { fg = "dragonBlack6", bg = "dragonBlack0" }
+"ui.statusline.normal" = { fg = "dragonBlack3", bg = "dragonBlue2", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "dragonBlack3", bg = "springGreen", modifiers = ["bold"]  }
+"ui.statusline.select" = { fg = "dragonBlack3", bg = "dragonViolet", modifiers = ["bold"]  }
+
+"ui.popup" = { fg = "oldWhite", bg = "dragonBlack0" }
+"ui.window" = { fg = "dragonBlack0" }
+"ui.help" = { fg = "oldWhite", bg = "dragonBlack0" }
+
+"ui.bufferline" = { fg = "oldWhite", bg = "dragonBlack0" }
+"ui.bufferline.active" = { fg = "dragonViolet", bg = "dragonBlack3", underline = { color = "dragonViolet", style = "line" } }
+"ui.bufferline.background" = { bg = "dragonBlack0" }
+
+"ui.text" = "dragonWhite"
+"ui.text.focus" = { fg = "dragonWhite", bg = "dragonBlack4", modifiers = ["bold"] }
+"ui.text.inactive" = { fg = "dragonBlack6" }
+"ui.text.directory" = { fg = "dragonBlue2" }
+
+"ui.virtual" = "dragonBlack6"
+"ui.virtual.ruler" = { bg = "dragonBlack4" }
+"ui.virtual.indent-guide" = "dragonBlack4"
+"ui.virtual.inlay-hint" = { fg = "dragonBlack6", bg = "dragonBlack2" }
+"ui.virtual.jump-label" = { fg = "dragonRed", modifiers = ["bold"] }
+
+"ui.selection" = { bg = "waveBlue1" }
+
+"ui.cursor" = { fg = "dragonBlack3", bg = "oldWhite" }
+"ui.cursor.primary" = { fg = "dragonBlack3", bg = "dragonWhite" }
+"ui.cursor.match" = { fg = "roninYellow", modifiers = ["bold"] }
+
+"ui.cursor.primary.normal" = { fg = "dragonBlack3", bg = "dragonWhite" }
+"ui.cursor.primary.insert" = { fg = "dragonBlack3", bg = "dragonWhite" }
+"ui.cursor.primary.select" = { fg = "dragonBlack3", bg = "dragonWhite" }
+
+"ui.cursor.normal" = { fg = "dragonBlack3", bg = "oldWhite" }
+"ui.cursor.insert" = { fg = "dragonBlack3", bg = "oldWhite" }
+"ui.cursor.select" = { fg = "dragonBlack3", bg = "oldWhite" }
+
+"ui.cursorline.primary" = { bg = "dragonBlack5" }
+
+"ui.highlight" = { bg = "dragonBlack4", modifiers = ["bold"] }
+
+"ui.menu" = { fg = "fujiWhite", bg = "waveBlue1" }
+"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
+
+"diagnostic.error" = { underline = { color = "samuraiRed", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "roninYellow", style = "curl" } }
+"diagnostic.info" = { underline = { color = "dragonBlue", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "waveAqua1", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+error = "samuraiRed"
+warning = "roninYellow"
+info = "dragonBlue"
+hint = "waveAqua1"
+
+rainbow = ["dragonRed", "dragonOrange", "dragonYellow", "dragonGreen2", "dragonTeal", "dragonViolet"]
+
+[palette]
+sumiInk0 = "#16161D"
+sumiInk1 = "#181820"
+sumiInk2 = "#1a1a22"
+sumiInk3 = "#1F1F28"
+sumiInk4 = "#2A2A37"
+sumiInk5 = "#363646"
+sumiInk6 = "#54546D"
+waveBlue1 = "#223249"
+waveBlue2 = "#2D4F67"
+winterGreen = "#2B3328"
+winterYellow = "#49443C"
+winterRed = "#43242B"
+winterBlue = "#252535"
+autumnGreen = "#76946A"
+autumnRed = "#C34043"
+autumnYellow = "#DCA561"
+samuraiRed = "#E82424"
+roninYellow = "#FF9E3B"
+waveAqua1 = "#6A9589"
+dragonBlue = "#658594"
+oldWhite = "#C8C093"
+fujiWhite = "#DCD7BA"
+fujiGray = "#727169"
+oniViolet = "#957FB8"
+oniViolet2 = "#b8b4d0"
+crystalBlue = "#7E9CD8"
+springViolet1 = "#938AA9"
+springViolet2 = "#9CABCA"
+springBlue = "#7FB4CA"
+lightBlue = "#A3D4D5"
+waveAqua2 = "#7AA89F"
+springGreen = "#98BB6C"
+boatYellow1 = "#938056"
+boatYellow2 = "#C0A36E"
+carpYellow = "#E6C384"
+sakuraPink = "#D27E99"
+waveRed = "#E46876"
+peachRed = "#FF5D62"
+surimiOrange = "#FFA066"
+katanaGray = "#717C7C"
+dragonBlack0 = "#0d0c0c"
+dragonBlack1 = "#12120f"
+dragonBlack2 = "#1D1C19"
+dragonBlack3 = "#181616"
+dragonBlack4 = "#282727"
+dragonBlack5 = "#393836"
+dragonBlack6 = "#625e5a"
+dragonWhite = "#c5c9c5"
+dragonGreen = "#87a987"
+dragonGreen2 = "#8a9a7b"
+dragonPink = "#a292a3"
+dragonOrange = "#b6927b"
+dragonOrange2 = "#b98d7b"
+dragonGray = "#a6a69c"
+dragonGray2 = "#9e9b93"
+dragonGray3 = "#7a8382"
+dragonBlue2 = "#8ba4b0"
+dragonViolet = "#8992a7"
+dragonRed = "#c4746e"
+dragonAqua = "#8ea4a2"
+dragonAsh = "#737c73"
+dragonTeal = "#949fb5"
+dragonYellow = "#c4b28a"
+lotusInk1 = "#545464"
+lotusInk2 = "#43436c"
+lotusGray = "#dcd7ba"
+lotusGray2 = "#716e61"
+lotusGray3 = "#8a8980"
+lotusWhite0 = "#d5cea3"
+lotusWhite1 = "#dcd5ac"
+lotusWhite2 = "#e5ddb0"
+lotusWhite3 = "#f2ecbc"
+lotusWhite4 = "#e7dba0"
+lotusWhite5 = "#e4d794"
+lotusViolet1 = "#a09cac"
+lotusViolet2 = "#766b90"
+lotusViolet3 = "#c9cbd1"
+lotusViolet4 = "#624c83"
+lotusBlue1 = "#c7d7e0"
+lotusBlue2 = "#b5cbd2"
+lotusBlue3 = "#9fb5c9"
+lotusBlue4 = "#4d699b"
+lotusBlue5 = "#5d57a3"
+lotusGreen = "#6f894e"
+lotusGreen2 = "#6e915f"
+lotusGreen3 = "#b7d0ae"
+lotusPink = "#b35b79"
+lotusOrange = "#cc6d00"
+lotusOrange2 = "#e98a00"
+lotusYellow = "#77713f"
+lotusYellow2 = "#836f4a"
+lotusYellow3 = "#de9800"
+lotusYellow4 = "#f9d791"
+lotusRed = "#c84053"
+lotusRed2 = "#d7474b"
+lotusRed3 = "#e82424"
+lotusRed4 = "#d9a594"
+lotusAqua = "#597b75"
+lotusAqua2 = "#5e857a"
+lotusTeal1 = "#4e8ca2"
+lotusTeal2 = "#6693bf"
+lotusTeal3 = "#5a7785"
+lotusCyan = "#d7e3d8"

--- a/extras/helix/kanagawa-lotus.toml
+++ b/extras/helix/kanagawa-lotus.toml
@@ -1,0 +1,249 @@
+# Syntax highlighting
+# -------------------
+"attribute" = "lotusOrange"
+
+"type" = "lotusAqua"
+"type.builtin" = "lotusAqua"
+"type.enum.variant" = "lotusAqua"
+
+"constructor" = "lotusTeal2"
+
+"constant" = "lotusOrange"
+"constant.numeric" = "lotusPink"
+"constant.character" = "lotusGreen"
+"constant.character.escape" = "lotusYellow2"
+
+"string" = "lotusGreen"
+"string.regexp" = "lotusYellow2"
+"string.special" = "lotusTeal2"
+"string.special.symbol" = "lotusYellow"
+"string.special.url" = { fg = "lotusTeal2", underline = { color = "lotusTeal2", style = "curl" } }
+
+"comment" = { fg = "lotusGray3", modifiers = ["italic"] }
+
+"variable" = "lotusInk1"
+"variable.parameter" = "lotusBlue5"
+"variable.builtin" = "lotusRed"
+"variable.other.member" = "lotusYellow"
+
+"label" = "lotusTeal2"
+
+"punctuation" = "lotusTeal1"
+"punctuation.special" = "lotusTeal2"
+
+"keyword" = { fg = "lotusViolet4", modifiers = ["italic"] }
+"keyword.control.conditional" = { fg = "lotusViolet4", modifiers = ["italic"] }
+"keyword.control.import" = { fg = "lotusViolet4", modifiers = ["italic"] }
+"keyword.control.return" = { fg = "lotusRed", modifiers = ["italic"] }
+"keyword.control.exception" = { fg = "lotusRed", modifiers = ["bold"] }
+"keyword.function" = { fg = "lotusViolet4", modifiers = ["italic"] }
+"keyword.directive" = "lotusRed"
+"keyword.directive.define" = "lotusRed"
+"keyword.operator" = { fg = "lotusYellow2", modifiers = ["bold"] }
+
+"operator" = "lotusYellow2"
+
+"function" = "lotusBlue4"
+"function.macro" = "lotusRed"
+
+"tag" = "lotusBlue4"
+
+"namespace" = "lotusYellow"
+
+"special" = "lotusTeal2"
+
+"markup.heading" = "lotusBlue4"
+"markup.heading.1" = "lotusBlue4"
+"markup.heading.2" = "lotusBlue4"
+"markup.heading.3" = "lotusBlue4"
+"markup.heading.4" = "lotusBlue4"
+"markup.heading.5" = "lotusBlue4"
+"markup.heading.6" = "lotusBlue4"
+"markup.list" = "lotusTeal2"
+"markup.list.unchecked" = "lotusViolet1"
+"markup.list.checked" = "lotusGreen"
+"markup.bold" = { fg = "lotusRed", modifiers = ["bold"] }
+"markup.italic" = { fg = "lotusRed", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.underline" = { modifiers = ["underlined"] }
+"markup.link.url" = { fg = "lotusTeal2", underline = { color = "lotusTeal2", style = "curl" } }
+"markup.link.text" = "lotusViolet4"
+"markup.link.label" = "lotusYellow"
+"markup.raw" = "lotusGreen"
+"markup.quote" = "lotusBlue5"
+
+"diff.plus" = "lotusGreen2"
+"diff.minus" = "lotusRed2"
+"diff.delta" = "lotusYellow3"
+
+# User Interface
+# --------------
+"ui.background" = { fg = "lotusInk1", bg = "lotusWhite3" }
+
+"ui.linenr" = { fg = "lotusViolet1" }
+"ui.linenr.selected" = { fg = "lotusOrange2" }
+
+"ui.statusline" = { fg = "lotusInk2", bg = "lotusWhite0" }
+"ui.statusline.inactive" = { fg = "lotusViolet1", bg = "lotusWhite0" }
+"ui.statusline.normal" = { fg = "lotusWhite3", bg = "lotusBlue4", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "lotusWhite3", bg = "lotusGreen", modifiers = ["bold"]  }
+"ui.statusline.select" = { fg = "lotusWhite3", bg = "lotusViolet4", modifiers = ["bold"]  }
+
+"ui.popup" = { fg = "lotusInk2", bg = "lotusWhite0" }
+"ui.window" = { fg = "lotusWhite0" }
+"ui.help" = { fg = "lotusInk2", bg = "lotusWhite0" }
+
+"ui.bufferline" = { fg = "lotusInk2", bg = "lotusWhite0" }
+"ui.bufferline.active" = { fg = "lotusViolet4", bg = "lotusWhite3", underline = { color = "lotusViolet4", style = "line" } }
+"ui.bufferline.background" = { bg = "lotusWhite0" }
+
+"ui.text" = "lotusInk1"
+"ui.text.focus" = { fg = "lotusInk1", bg = "lotusWhite4", modifiers = ["bold"] }
+"ui.text.inactive" = { fg = "lotusViolet1" }
+"ui.text.directory" = { fg = "lotusBlue4" }
+
+"ui.virtual" = "lotusViolet1"
+"ui.virtual.ruler" = { bg = "lotusWhite4" }
+"ui.virtual.indent-guide" = "lotusWhite4"
+"ui.virtual.inlay-hint" = { fg = "lotusViolet1", bg = "lotusWhite2" }
+"ui.virtual.jump-label" = { fg = "lotusRed", modifiers = ["bold"] }
+
+"ui.selection" = { bg = "lotusViolet3" }
+
+"ui.cursor" = { fg = "lotusWhite3", bg = "lotusInk2" }
+"ui.cursor.primary" = { fg = "lotusWhite3", bg = "lotusInk1" }
+"ui.cursor.match" = { fg = "lotusOrange2", modifiers = ["bold"] }
+
+"ui.cursor.primary.normal" = { fg = "lotusWhite3", bg = "lotusInk1" }
+"ui.cursor.primary.insert" = { fg = "lotusWhite3", bg = "lotusInk1" }
+"ui.cursor.primary.select" = { fg = "lotusWhite3", bg = "lotusInk1" }
+
+"ui.cursor.normal" = { fg = "lotusWhite3", bg = "lotusInk2" }
+"ui.cursor.insert" = { fg = "lotusWhite3", bg = "lotusInk2" }
+"ui.cursor.select" = { fg = "lotusWhite3", bg = "lotusInk2" }
+
+"ui.cursorline.primary" = { bg = "lotusWhite5" }
+
+"ui.highlight" = { bg = "lotusWhite4", modifiers = ["bold"] }
+
+"ui.menu" = { fg = "lotusInk2", bg = "lotusBlue1" }
+"ui.menu.selected" = { fg = "lotusInk1", bg = "lotusBlue3", modifiers = ["bold"] }
+
+"diagnostic.error" = { underline = { color = "lotusRed3", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "lotusOrange2", style = "curl" } }
+"diagnostic.info" = { underline = { color = "lotusTeal3", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "lotusAqua2", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+error = "lotusRed3"
+warning = "lotusOrange2"
+info = "lotusTeal3"
+hint = "lotusAqua2"
+
+rainbow = ["lotusRed", "lotusOrange", "lotusYellow", "lotusGreen", "lotusTeal2", "lotusViolet4"]
+
+[palette]
+sumiInk0 = "#16161D"
+sumiInk1 = "#181820"
+sumiInk2 = "#1a1a22"
+sumiInk3 = "#1F1F28"
+sumiInk4 = "#2A2A37"
+sumiInk5 = "#363646"
+sumiInk6 = "#54546D"
+waveBlue1 = "#223249"
+waveBlue2 = "#2D4F67"
+winterGreen = "#2B3328"
+winterYellow = "#49443C"
+winterRed = "#43242B"
+winterBlue = "#252535"
+autumnGreen = "#76946A"
+autumnRed = "#C34043"
+autumnYellow = "#DCA561"
+samuraiRed = "#E82424"
+roninYellow = "#FF9E3B"
+waveAqua1 = "#6A9589"
+dragonBlue = "#658594"
+oldWhite = "#C8C093"
+fujiWhite = "#DCD7BA"
+fujiGray = "#727169"
+oniViolet = "#957FB8"
+oniViolet2 = "#b8b4d0"
+crystalBlue = "#7E9CD8"
+springViolet1 = "#938AA9"
+springViolet2 = "#9CABCA"
+springBlue = "#7FB4CA"
+lightBlue = "#A3D4D5"
+waveAqua2 = "#7AA89F"
+springGreen = "#98BB6C"
+boatYellow1 = "#938056"
+boatYellow2 = "#C0A36E"
+carpYellow = "#E6C384"
+sakuraPink = "#D27E99"
+waveRed = "#E46876"
+peachRed = "#FF5D62"
+surimiOrange = "#FFA066"
+katanaGray = "#717C7C"
+dragonBlack0 = "#0d0c0c"
+dragonBlack1 = "#12120f"
+dragonBlack2 = "#1D1C19"
+dragonBlack3 = "#181616"
+dragonBlack4 = "#282727"
+dragonBlack5 = "#393836"
+dragonBlack6 = "#625e5a"
+dragonWhite = "#c5c9c5"
+dragonGreen = "#87a987"
+dragonGreen2 = "#8a9a7b"
+dragonPink = "#a292a3"
+dragonOrange = "#b6927b"
+dragonOrange2 = "#b98d7b"
+dragonGray = "#a6a69c"
+dragonGray2 = "#9e9b93"
+dragonGray3 = "#7a8382"
+dragonBlue2 = "#8ba4b0"
+dragonViolet = "#8992a7"
+dragonRed = "#c4746e"
+dragonAqua = "#8ea4a2"
+dragonAsh = "#737c73"
+dragonTeal = "#949fb5"
+dragonYellow = "#c4b28a"
+lotusInk1 = "#545464"
+lotusInk2 = "#43436c"
+lotusGray = "#dcd7ba"
+lotusGray2 = "#716e61"
+lotusGray3 = "#8a8980"
+lotusWhite0 = "#d5cea3"
+lotusWhite1 = "#dcd5ac"
+lotusWhite2 = "#e5ddb0"
+lotusWhite3 = "#f2ecbc"
+lotusWhite4 = "#e7dba0"
+lotusWhite5 = "#e4d794"
+lotusViolet1 = "#a09cac"
+lotusViolet2 = "#766b90"
+lotusViolet3 = "#c9cbd1"
+lotusViolet4 = "#624c83"
+lotusBlue1 = "#c7d7e0"
+lotusBlue2 = "#b5cbd2"
+lotusBlue3 = "#9fb5c9"
+lotusBlue4 = "#4d699b"
+lotusBlue5 = "#5d57a3"
+lotusGreen = "#6f894e"
+lotusGreen2 = "#6e915f"
+lotusGreen3 = "#b7d0ae"
+lotusPink = "#b35b79"
+lotusOrange = "#cc6d00"
+lotusOrange2 = "#e98a00"
+lotusYellow = "#77713f"
+lotusYellow2 = "#836f4a"
+lotusYellow3 = "#de9800"
+lotusYellow4 = "#f9d791"
+lotusRed = "#c84053"
+lotusRed2 = "#d7474b"
+lotusRed3 = "#e82424"
+lotusRed4 = "#d9a594"
+lotusAqua = "#597b75"
+lotusAqua2 = "#5e857a"
+lotusTeal1 = "#4e8ca2"
+lotusTeal2 = "#6693bf"
+lotusTeal3 = "#5a7785"
+lotusCyan = "#d7e3d8"

--- a/extras/helix/kanagawa-wave.toml
+++ b/extras/helix/kanagawa-wave.toml
@@ -1,0 +1,249 @@
+# Syntax highlighting
+# -------------------
+"attribute" = "surimiOrange"
+
+"type" = "waveAqua2"
+"type.builtin" = "waveAqua2"
+"type.enum.variant" = "waveAqua2"
+
+"constructor" = "springBlue"
+
+"constant" = "surimiOrange"
+"constant.numeric" = "sakuraPink"
+"constant.character" = "springGreen"
+"constant.character.escape" = "boatYellow2"
+
+"string" = "springGreen"
+"string.regexp" = "boatYellow2"
+"string.special" = "springBlue"
+"string.special.symbol" = "carpYellow"
+"string.special.url" = { fg = "springBlue", underline = { color = "springBlue", style = "curl" } }
+
+"comment" = { fg = "fujiGray", modifiers = ["italic"] }
+
+"variable" = "fujiWhite"
+"variable.parameter" = "oniViolet2"
+"variable.builtin" = "waveRed"
+"variable.other.member" = "carpYellow"
+
+"label" = "springBlue"
+
+"punctuation" = "springViolet2"
+"punctuation.special" = "springBlue"
+
+"keyword" = { fg = "oniViolet", modifiers = ["italic"] }
+"keyword.control.conditional" = { fg = "oniViolet", modifiers = ["italic"] }
+"keyword.control.import" = { fg = "oniViolet", modifiers = ["italic"] }
+"keyword.control.return" = { fg = "peachRed", modifiers = ["italic"] }
+"keyword.control.exception" = { fg = "peachRed", modifiers = ["bold"] }
+"keyword.function" = { fg = "oniViolet", modifiers = ["italic"] }
+"keyword.directive" = "waveRed"
+"keyword.directive.define" = "waveRed"
+"keyword.operator" = { fg = "boatYellow2", modifiers = ["bold"] }
+
+"operator" = "boatYellow2"
+
+"function" = "crystalBlue"
+"function.macro" = "waveRed"
+
+"tag" = "crystalBlue"
+
+"namespace" = "carpYellow"
+
+"special" = "springBlue"
+
+"markup.heading" = "crystalBlue"
+"markup.heading.1" = "crystalBlue"
+"markup.heading.2" = "crystalBlue"
+"markup.heading.3" = "crystalBlue"
+"markup.heading.4" = "crystalBlue"
+"markup.heading.5" = "crystalBlue"
+"markup.heading.6" = "crystalBlue"
+"markup.list" = "springBlue"
+"markup.list.unchecked" = "sumiInk6"
+"markup.list.checked" = "springGreen"
+"markup.bold" = { fg = "waveRed", modifiers = ["bold"] }
+"markup.italic" = { fg = "waveRed", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.underline" = { modifiers = ["underlined"] }
+"markup.link.url" = { fg = "springBlue", underline = { color = "springBlue", style = "curl" } }
+"markup.link.text" = "oniViolet"
+"markup.link.label" = "carpYellow"
+"markup.raw" = "springGreen"
+"markup.quote" = "oniViolet2"
+
+"diff.plus" = "autumnGreen"
+"diff.minus" = "autumnRed"
+"diff.delta" = "autumnYellow"
+
+# User Interface
+# --------------
+"ui.background" = { fg = "fujiWhite", bg = "sumiInk3" }
+
+"ui.linenr" = { fg = "sumiInk6" }
+"ui.linenr.selected" = { fg = "roninYellow" }
+
+"ui.statusline" = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.statusline.inactive" = { fg = "sumiInk6", bg = "sumiInk0" }
+"ui.statusline.normal" = { fg = "sumiInk3", bg = "crystalBlue", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "sumiInk3", bg = "springGreen", modifiers = ["bold"]  }
+"ui.statusline.select" = { fg = "sumiInk3", bg = "oniViolet", modifiers = ["bold"]  }
+
+"ui.popup" = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.window" = { fg = "sumiInk0" }
+"ui.help" = { fg = "oldWhite", bg = "sumiInk0" }
+
+"ui.bufferline" = { fg = "oldWhite", bg = "sumiInk0" }
+"ui.bufferline.active" = { fg = "oniViolet", bg = "sumiInk3", underline = { color = "oniViolet", style = "line" } }
+"ui.bufferline.background" = { bg = "sumiInk0" }
+
+"ui.text" = "fujiWhite"
+"ui.text.focus" = { fg = "fujiWhite", bg = "sumiInk4", modifiers = ["bold"] }
+"ui.text.inactive" = { fg = "sumiInk6" }
+"ui.text.directory" = { fg = "crystalBlue" }
+
+"ui.virtual" = "sumiInk6"
+"ui.virtual.ruler" = { bg = "sumiInk4" }
+"ui.virtual.indent-guide" = "sumiInk4"
+"ui.virtual.inlay-hint" = { fg = "sumiInk6", bg = "sumiInk2" }
+"ui.virtual.jump-label" = { fg = "waveRed", modifiers = ["bold"] }
+
+"ui.selection" = { bg = "waveBlue1" }
+
+"ui.cursor" = { fg = "sumiInk3", bg = "oldWhite" }
+"ui.cursor.primary" = { fg = "sumiInk3", bg = "fujiWhite" }
+"ui.cursor.match" = { fg = "roninYellow", modifiers = ["bold"] }
+
+"ui.cursor.primary.normal" = { fg = "sumiInk3", bg = "fujiWhite" }
+"ui.cursor.primary.insert" = { fg = "sumiInk3", bg = "fujiWhite" }
+"ui.cursor.primary.select" = { fg = "sumiInk3", bg = "fujiWhite" }
+
+"ui.cursor.normal" = { fg = "sumiInk3", bg = "oldWhite" }
+"ui.cursor.insert" = { fg = "sumiInk3", bg = "oldWhite" }
+"ui.cursor.select" = { fg = "sumiInk3", bg = "oldWhite" }
+
+"ui.cursorline.primary" = { bg = "sumiInk5" }
+
+"ui.highlight" = { bg = "sumiInk4", modifiers = ["bold"] }
+
+"ui.menu" = { fg = "fujiWhite", bg = "waveBlue1" }
+"ui.menu.selected" = { fg = "fujiWhite", bg = "waveBlue2", modifiers = ["bold"] }
+
+"diagnostic.error" = { underline = { color = "samuraiRed", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "roninYellow", style = "curl" } }
+"diagnostic.info" = { underline = { color = "dragonBlue", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "waveAqua1", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+error = "samuraiRed"
+warning = "roninYellow"
+info = "dragonBlue"
+hint = "waveAqua1"
+
+rainbow = ["waveRed", "surimiOrange", "carpYellow", "springGreen", "springBlue", "oniViolet"]
+
+[palette]
+sumiInk0 = "#16161D"
+sumiInk1 = "#181820"
+sumiInk2 = "#1a1a22"
+sumiInk3 = "#1F1F28"
+sumiInk4 = "#2A2A37"
+sumiInk5 = "#363646"
+sumiInk6 = "#54546D"
+waveBlue1 = "#223249"
+waveBlue2 = "#2D4F67"
+winterGreen = "#2B3328"
+winterYellow = "#49443C"
+winterRed = "#43242B"
+winterBlue = "#252535"
+autumnGreen = "#76946A"
+autumnRed = "#C34043"
+autumnYellow = "#DCA561"
+samuraiRed = "#E82424"
+roninYellow = "#FF9E3B"
+waveAqua1 = "#6A9589"
+dragonBlue = "#658594"
+oldWhite = "#C8C093"
+fujiWhite = "#DCD7BA"
+fujiGray = "#727169"
+oniViolet = "#957FB8"
+oniViolet2 = "#b8b4d0"
+crystalBlue = "#7E9CD8"
+springViolet1 = "#938AA9"
+springViolet2 = "#9CABCA"
+springBlue = "#7FB4CA"
+lightBlue = "#A3D4D5"
+waveAqua2 = "#7AA89F"
+springGreen = "#98BB6C"
+boatYellow1 = "#938056"
+boatYellow2 = "#C0A36E"
+carpYellow = "#E6C384"
+sakuraPink = "#D27E99"
+waveRed = "#E46876"
+peachRed = "#FF5D62"
+surimiOrange = "#FFA066"
+katanaGray = "#717C7C"
+dragonBlack0 = "#0d0c0c"
+dragonBlack1 = "#12120f"
+dragonBlack2 = "#1D1C19"
+dragonBlack3 = "#181616"
+dragonBlack4 = "#282727"
+dragonBlack5 = "#393836"
+dragonBlack6 = "#625e5a"
+dragonWhite = "#c5c9c5"
+dragonGreen = "#87a987"
+dragonGreen2 = "#8a9a7b"
+dragonPink = "#a292a3"
+dragonOrange = "#b6927b"
+dragonOrange2 = "#b98d7b"
+dragonGray = "#a6a69c"
+dragonGray2 = "#9e9b93"
+dragonGray3 = "#7a8382"
+dragonBlue2 = "#8ba4b0"
+dragonViolet = "#8992a7"
+dragonRed = "#c4746e"
+dragonAqua = "#8ea4a2"
+dragonAsh = "#737c73"
+dragonTeal = "#949fb5"
+dragonYellow = "#c4b28a"
+lotusInk1 = "#545464"
+lotusInk2 = "#43436c"
+lotusGray = "#dcd7ba"
+lotusGray2 = "#716e61"
+lotusGray3 = "#8a8980"
+lotusWhite0 = "#d5cea3"
+lotusWhite1 = "#dcd5ac"
+lotusWhite2 = "#e5ddb0"
+lotusWhite3 = "#f2ecbc"
+lotusWhite4 = "#e7dba0"
+lotusWhite5 = "#e4d794"
+lotusViolet1 = "#a09cac"
+lotusViolet2 = "#766b90"
+lotusViolet3 = "#c9cbd1"
+lotusViolet4 = "#624c83"
+lotusBlue1 = "#c7d7e0"
+lotusBlue2 = "#b5cbd2"
+lotusBlue3 = "#9fb5c9"
+lotusBlue4 = "#4d699b"
+lotusBlue5 = "#5d57a3"
+lotusGreen = "#6f894e"
+lotusGreen2 = "#6e915f"
+lotusGreen3 = "#b7d0ae"
+lotusPink = "#b35b79"
+lotusOrange = "#cc6d00"
+lotusOrange2 = "#e98a00"
+lotusYellow = "#77713f"
+lotusYellow2 = "#836f4a"
+lotusYellow3 = "#de9800"
+lotusYellow4 = "#f9d791"
+lotusRed = "#c84053"
+lotusRed2 = "#d7474b"
+lotusRed3 = "#e82424"
+lotusRed4 = "#d9a594"
+lotusAqua = "#597b75"
+lotusAqua2 = "#5e857a"
+lotusTeal1 = "#4e8ca2"
+lotusTeal2 = "#6693bf"
+lotusTeal3 = "#5a7785"
+lotusCyan = "#d7e3d8"


### PR DESCRIPTION
This PR adds the Kanagawa themes to the [Helix](https://helix-editor.com/) editor.

<img width="1964" height="1432" alt="Screenshot From 2026-01-23 13-44-37" src="https://github.com/user-attachments/assets/b987d90b-3f41-4269-9352-8a5e7f0af61f" />
