### PR TITLE
Add themes for micro

### DIFF
--- a/extras/micro/kanagawa-dragon.micro
+++ b/extras/micro/kanagawa-dragon.micro
@@ -1,0 +1,42 @@
+color-link default "#C5C9C5,#181616"
+color-link comment "#737C73"
+
+color-link identifier "#C4B28A"
+color-link identifier.class "#8EA4A2"
+color-link identifier.var "#C4B28A"
+
+color-link constant "#B6927B"
+color-link constant.number "#A292A3"
+color-link constant.string "#8A9A7B"
+
+color-link symbol "#949FB5"
+color-link symbol.brackets "#9E9B93"
+color-link symbol.tag "#949FB5"
+
+color-link type "#8EA4A2"
+color-link type.keyword "#8EA4A2"
+
+color-link special "#949FB5"
+color-link statement "#8992A7"
+color-link preproc "#C4746E"
+
+color-link underlined "#949FB5"
+color-link error "bold #E82424"
+color-link todo "bold #FF9E3B"
+
+color-link diff-added "#76946A"
+color-link diff-modified "#DCA561"
+color-link diff-deleted "#C34043"
+
+color-link gutter-error "#E82424"
+color-link gutter-warning "#FF9E3B"
+
+color-link statusline "#C8C093,#0D0C0C"
+color-link tabbar "#C8C093,#0D0C0C"
+color-link indent-char "#625E5A"
+color-link line-number "#625E5A"
+color-link current-line-number "#FF9E3B"
+
+color-link cursor-line "#393836,#C5C9C5"
+color-link color-column "#282727"
+color-link type.extended "default"

--- a/extras/micro/kanagawa-lotus.micro
+++ b/extras/micro/kanagawa-lotus.micro
@@ -1,0 +1,42 @@
+color-link default "#545464,#F2ECBC"
+color-link comment "#8A8980"
+
+color-link identifier "#77713F"
+color-link identifier.class "#597B75"
+color-link identifier.var "#77713F"
+
+color-link constant "#CC6D00"
+color-link constant.number "#B35B79"
+color-link constant.string "#6F894E"
+
+color-link symbol "#6693BF"
+color-link symbol.brackets "#4E8CA2"
+color-link symbol.tag "#6693BF"
+
+color-link type "#597B75"
+color-link type.keyword "#597B75"
+
+color-link special "#6693BF"
+color-link statement "#624C83"
+color-link preproc "#C84053"
+
+color-link underlined "#6693BF"
+color-link error "bold #E82424"
+color-link todo "bold #E98A00"
+
+color-link diff-added "#6E915F"
+color-link diff-modified "#DE9800"
+color-link diff-deleted "#D7474B"
+
+color-link gutter-error "#E82424"
+color-link gutter-warning "#E98A00"
+
+color-link statusline "#43436C,#D5CEA3"
+color-link tabbar "#43436C,#D5CEA3"
+color-link indent-char "#A09CAC"
+color-link line-number "#A09CAC"
+color-link current-line-number "#E98A00"
+
+color-link cursor-line "#E4D794,#545464"
+color-link color-column "#E7DBA0"
+color-link type.extended "default"

--- a/extras/micro/kanagawa-wave.micro
+++ b/extras/micro/kanagawa-wave.micro
@@ -1,0 +1,42 @@
+color-link default "#DCD7BA,#1F1F28"
+color-link comment "#727169"
+
+color-link identifier "#E6C384"
+color-link identifier.class "#7AA89F"
+color-link identifier.var "#E6C384"
+
+color-link constant "#FFA066"
+color-link constant.number "#D27E99"
+color-link constant.string "#98BB6C"
+
+color-link symbol "#7FB4CA"
+color-link symbol.brackets "#9CABCA"
+color-link symbol.tag "#7FB4CA"
+
+color-link type "#7AA89F"
+color-link type.keyword "#7AA89F"
+
+color-link special "#7FB4CA"
+color-link statement "#957FB8"
+color-link preproc "#E46876"
+
+color-link underlined "#7FB4CA"
+color-link error "bold #E82424"
+color-link todo "bold #FF9E3B"
+
+color-link diff-added "#76946A"
+color-link diff-modified "#DCA561"
+color-link diff-deleted "#C34043"
+
+color-link gutter-error "#E82424"
+color-link gutter-warning "#FF9E3B"
+
+color-link statusline "#C8C093,#16161D"
+color-link tabbar "#C8C093,#16161D"
+color-link indent-char "#54546D"
+color-link line-number "#54546D"
+color-link current-line-number "#FF9E3B"
+
+color-link cursor-line "#363646,#DCD7BA"
+color-link color-column "#2A2A37"
+color-link type.extended "default"


### PR DESCRIPTION
This PR adds the Kanagawa themes for the [micro editor](https://micro-editor.github.io/).

<img width="1964" height="1432" alt="Screenshot From 2026-01-23 14-01-58" src="https://github.com/user-attachments/assets/9a04e760-82ef-4fab-bad3-0ba66ad62e80" />
