### PR TITLE
feat(extras): add lotus and dragon flavors for foot terminal and fix warning

### DIFF
--- a/extras/foot/kanagawa-dragon.ini
+++ b/extras/foot/kanagawa-dragon.ini
@@ -1,0 +1,32 @@
+# Kanagawa Dragon Colors
+
+[main]
+initial-color-theme=dark
+
+[colors-dark]
+foreground = c5c9c5
+background = 181616
+
+selection-foreground = c8c093
+selection-background = 2d4f67
+
+regular0 = 0d0c0c
+regular1 = c4746e
+regular2 = 8a9a7b
+regular3 = c4b28a
+regular4 = 8ba4b0
+regular5 = a292a3
+regular6 = 8ea4a2
+regular7 = c8c093
+
+bright0  = a6a69c
+bright1  = e46876
+bright2  = 87a987
+bright3  = e6c384
+bright4  = 7fb4ca
+bright5  = 938aa9
+bright6  = 7aa89f
+bright7  = c5c9c5
+
+16       = b6927b
+17       = b98d7b

--- a/extras/foot/kanagawa-lotus.ini
+++ b/extras/foot/kanagawa-lotus.ini
@@ -1,0 +1,32 @@
+# Kanagawa Lotus Colors
+
+[main]
+initial-color-theme=light
+
+[colors-light]
+foreground = 545464
+background = f2ecbc
+
+selection-foreground = dcd7ba
+selection-background = c9cbd1
+
+regular0 = 1f1f28
+regular1 = c84053
+regular2 = 6f894e
+regular3 = 77713f
+regular4 = 4d699b
+regular5 = b35b79
+regular6 = 597b75
+regular7 = 545464
+
+bright0  = 8a8980
+bright1  = d7474b
+bright2  = 6e915f
+bright3  = 836f4a
+bright4  = 6693bf
+bright5  = 624c83
+bright6  = 5e857a
+bright7  = 43436c
+
+16       = e98a00
+17       = e82424

--- a/extras/foot/kanagawa-wave.ini
+++ b/extras/foot/kanagawa-wave.ini
@@ -1,3 +1,8 @@
+# Kanagawa Wave Colors
+
+[main]
+initial-color-theme=dark
+
 [colors-dark]
 foreground = dcd7ba
 background = 1f1f28

--- a/extras/foot/kanagawa.ini
+++ b/extras/foot/kanagawa.ini
@@ -1,4 +1,4 @@
-[colors]
+[colors-dark]
 foreground = dcd7ba
 background = 1f1f28
 


### PR DESCRIPTION
The `foot` terminal now warns that `[colors]` is deprecated and recommends using `[colors-dark]`. This PR updates the extra template to reflect that.

<img width="599" height="568" alt="image" src="https://github.com/user-attachments/assets/1363a141-f92f-4a52-92e5-cd482d682fa2" />

UPD:
I have also added dragon and lotus flavors and renamed `kanagawa.ini` to `kanagawa-wave.ini` for consistency