### PR TITLE
feat: link @function.macro to Macro

### DIFF
--- a/lua/kanagawa/highlights/treesitter.lua
+++ b/lua/kanagawa/highlights/treesitter.lua
@@ -56,6 +56,7 @@ function M.setup(colors, config)
         -- @function.builtin       built-in functions
         -- @function.call          function calls
         -- @function.macro         preprocessor macros
+        ["@function.macro"] = { link = "Macro" },
         --
         -- @function.method        method definitions
         -- @function.method.call   method calls


### PR DESCRIPTION
Currently, `@function.macro` incorrectly links to `Function`, causing annoying flickering when LSP semantic tokens (using `Macro`) override treesitter. If I disable semantic tokens, I completely lose the correct macro highlighting.

As shown in the `:Inspect` screenshots below, only treesitter lacks a link to `Macro`. (actually `PreProc`, as `Macro` links to `PreProc`)

<img width="1034" height="213" alt="image" src="https://github.com/user-attachments/assets/bec72d34-9949-4344-87ab-48f05968a234" />
<img width="525" height="132" alt="image" src="https://github.com/user-attachments/assets/13f2d54d-6afa-4714-b539-852be9b6d105" />
