### PR TITLE
feat: line ["@lsp.type.variable"] to "@variable"

### DIFF
--- a/lua/kanagawa/highlights/lsp.lua
+++ b/lua/kanagawa/highlights/lsp.lua
@@ -19,7 +19,7 @@ function M.setup(colors, config)
         -- ["@lsp.type.struct"] = { link = "Structure" },
         -- ["@lsp.type.type"] = { link = "Type" },
         -- ["@lsp.type.typeParameter"] = { link = "TypeDef" },
-        ["@lsp.type.variable"] = { fg = "none" }, -- Identifier
+        ["@lsp.type.variable"] = { link = "@variable" }, -- Identifier
         ["@lsp.type.comment"] = { link = "Comment" },  -- Comment
 
         ["@lsp.type.const"] = { link = "Constant" },


### PR DESCRIPTION
this will solve the problem that highlights will not be shown in format block for example the snippet like

```rust
println!("Hello {a}");
```